### PR TITLE
6 토론방 기능 구현

### DIFF
--- a/src/main/java/com/fwaiya/princess_backend/PrincessBackendApplication.java
+++ b/src/main/java/com/fwaiya/princess_backend/PrincessBackendApplication.java
@@ -2,8 +2,10 @@ package com.fwaiya.princess_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PrincessBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/fwaiya/princess_backend/controller/AdminController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/AdminController.java
@@ -1,0 +1,17 @@
+package com.fwaiya.princess_backend.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@Tag(name = "07. 관리자 권한 기능 관리", description = " 스웨거에서 편리하게 관리자 권한 기능을 사용할 수 있습니다. ")
+@RequiredArgsConstructor
+public class AdminController {
+    /** 토론방 등록 **/
+
+    /** 토론방 삭제 **/
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/controller/AdminController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/AdminController.java
@@ -1,17 +1,32 @@
 package com.fwaiya.princess_backend.controller;
 
+import com.fwaiya.princess_backend.dto.request.DiscussionCreateRequest;
+import com.fwaiya.princess_backend.dto.response.DiscussionResponse;
+import com.fwaiya.princess_backend.service.DiscussionService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/admin")
 @Tag(name = "07. 관리자 권한 기능 관리", description = " 스웨거에서 편리하게 관리자 권한 기능을 사용할 수 있습니다. ")
 @RequiredArgsConstructor
 public class AdminController {
-    /** 토론방 등록 **/
+    private final DiscussionService discussionService;
 
-    /** 토론방 삭제 **/
+    /** 토론방 등록 **/
+    //security 수정하기
+    @PostMapping("/discussions")
+    @Operation(summary = "토론방 등록", description = "관리자가 토론방을 등록합니다.")
+    public ResponseEntity<Object> createDiscussions(
+            @RequestBody DiscussionCreateRequest discussionCreateRequest
+    ) {
+        discussionService.createDiscussion(discussionCreateRequest);
+        return ResponseEntity.ok("토론방 등록을 완료하였습니다.");
+    }
 
 }

--- a/src/main/java/com/fwaiya/princess_backend/controller/AdminController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/AdminController.java
@@ -13,15 +13,14 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/admin")
-@Tag(name = "07. 관리자 권한 기능 관리", description = " 스웨거에서 편리하게 관리자 권한 기능을 사용할 수 있습니다. ")
+@Tag(name = "07. 관리자 권한 기능 관리", description = " 관리자(1234@naver.com) 권한 기능을 사용할 수 있습니다. ")
 @RequiredArgsConstructor
 public class AdminController {
     private final DiscussionService discussionService;
 
     /** 토론방 등록 **/
-    //security 수정하기
     @PostMapping("/discussions")
-    @Operation(summary = "토론방 등록", description = "관리자가 토론방을 등록합니다.")
+    @Operation(summary = "토론방 등록", description = "관리자가 책 제목으로 토론방을 등록합니다.")
     public ResponseEntity<Object> createDiscussions(
             @RequestBody DiscussionCreateRequest discussionCreateRequest
     ) {

--- a/src/main/java/com/fwaiya/princess_backend/controller/BookController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/BookController.java
@@ -1,0 +1,73 @@
+package com.fwaiya.princess_backend.controller;
+
+import com.fwaiya.princess_backend.domain.Book;
+import com.fwaiya.princess_backend.dto.BookDto;
+import com.fwaiya.princess_backend.service.BookService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+// BookController는 책 정보에 대한 HTTP 요청을 처리하는 컨트롤러 계층
+// REST API 형식으로 URI와 메서드를 매핑 -> 요청에 대한 응답을 JSON 형태로 반환
+
+@RestController // 이 클래스가 REST API의 컨트롤러임을 선언 (ResponseBody + Controller 기능 결합)
+@RequestMapping("/api/books") // "/api/books" 경로로 시작하는 모든 요청 처리
+@RequiredArgsConstructor // 생성자 주입 방식으로 BookService 주입
+@Tag(name = "04. 책 관리", description = "책 정보 조회, 등록, 수정, 삭제 API") // Swagger UI 문서화용 설명 태그
+public class BookController {
+
+    private final BookService bookService; // 비즈니스 로직을 처리할 서비스 계층
+
+    // 책 등록 API [POST] /api/books
+
+    @Operation(summary = "책 등록", description = "새로운 책 정보를 등록합니다.")
+    @PostMapping
+    public ResponseEntity<Book> createBook(@RequestBody BookDto dto) {
+        Book createdBook = bookService.saveBook(dto);
+        return ResponseEntity.ok(createdBook); // 200 OK + 저장된 Book JSON 반환
+    }
+
+
+    // 전체 책 목록 조회 API [GET] /api/books
+
+    @Operation(summary = "전체 책 목록 조회", description = "등록된 모든 책 정보를 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<BookDto>> getAllBooks() {
+        List<BookDto> books = bookService.getAllBooks();
+        return ResponseEntity.ok(books); // 200 OK + 책 리스트
+    }
+
+
+    // 특정 책 조회 API [GET] /api/books/{id}
+    @Operation(summary = "특정 책 조회", description = "책 ID를 이용해 하나의 책 정보를 조회합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<BookDto> getBook(@PathVariable Long id) {
+        BookDto book = bookService.getBook(id);
+        return ResponseEntity.ok(book); // 200 OK + 단일 책 정보
+    }
+
+
+    // 책 수정 API [PUT] /api/books/{id}
+
+    @Operation(summary = "책 정보 수정", description = "기존 책 정보를 수정합니다.")
+    @PutMapping("/{id}")
+    public ResponseEntity<Book> updateBook(@PathVariable Long id, @RequestBody BookDto dto) {
+        Book updatedBook = bookService.updateBook(id, dto);
+        return ResponseEntity.ok(updatedBook); // 200 OK + 수정된 Book 정보
+    }
+
+
+    // 책 삭제 API [DELETE] /api/books/{id}
+
+    @Operation(summary = "책 삭제", description = "책 ID를 기준으로 해당 책을 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteBook(@PathVariable Long id) {
+        bookService.deleteBook(id);
+        return ResponseEntity.ok().build(); // 200 OK + 본문 없음
+    }
+}

--- a/src/main/java/com/fwaiya/princess_backend/controller/CommentController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/CommentController.java
@@ -1,0 +1,17 @@
+package com.fwaiya.princess_backend.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/discussions/{id}")
+@Tag(name = "06. 댓글 관리", description = "댓글 등록, 댓글 목록 조회 기능")
+@RequiredArgsConstructor
+public class CommentController {
+    /** 댓글 등록 기능**/
+
+    /** 댓글 목록 조회 기능**/
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/controller/CommentController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/CommentController.java
@@ -1,17 +1,49 @@
 package com.fwaiya.princess_backend.controller;
 
+import com.fwaiya.princess_backend.dto.request.CommentCreateRequest;
+import com.fwaiya.princess_backend.dto.request.DiscussionCreateRequest;
+import com.fwaiya.princess_backend.dto.response.CommentResponse;
+import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
+import com.fwaiya.princess_backend.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/discussions/{id}")
 @Tag(name = "06. 댓글 관리", description = "댓글 등록, 댓글 목록 조회 기능")
 @RequiredArgsConstructor
 public class CommentController {
-    /** 댓글 등록 기능**/
+    private final CommentService commentService;
 
-    /** 댓글 목록 조회 기능**/
+    /** 댓글 등록 기능**/
+    @PostMapping("/comments")
+    @Operation(summary = "댓글 등록", description = "사용자가 토론방에 댓글을 등록합니다.")
+    public ResponseEntity<Object> createComments(
+            @PathVariable Long id,
+            @RequestBody CommentCreateRequest commentCreateRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        commentService.createComment( id ,commentCreateRequest , customUserDetails);
+        return ResponseEntity.ok("댓글 등록을 완료하였습니다.");
+    }
+
+    /** 토론방 별 댓글 목록 조회 기능**/
+    @GetMapping("/comments")
+    @Operation(summary = "댓글 목록 조회", description = "토론방의 댓글 목록을 조회합니다.")
+    public ResponseEntity<Object> getComments(
+            @PathVariable Long id
+    ){
+        List<CommentResponse> comments = commentService.getAllComments(id);
+
+        return ResponseEntity.ok(comments);
+    }
+
+
 
 }

--- a/src/main/java/com/fwaiya/princess_backend/controller/DiscussionController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/DiscussionController.java
@@ -1,0 +1,18 @@
+package com.fwaiya.princess_backend.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/discussions")
+@Tag(name = "05. 토론방 관리", description = "토론방 CRUD")
+@RequiredArgsConstructor
+public class DiscussionController {
+
+    /** 토론방 전체 조회 **/
+
+    /** 토론방 개별 조회 **/
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/controller/DiscussionController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/DiscussionController.java
@@ -1,18 +1,43 @@
 package com.fwaiya.princess_backend.controller;
 
+import com.fwaiya.princess_backend.dto.response.DiscussionResponse;
+import com.fwaiya.princess_backend.global.api.ApiResponse;
+import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
+import com.fwaiya.princess_backend.service.DiscussionService;
+import com.fwaiya.princess_backend.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/discussions")
 @Tag(name = "05. 토론방 관리", description = "토론방 CRUD")
 @RequiredArgsConstructor
 public class DiscussionController {
+    private final UserService userService;
+    private final DiscussionService discussionService;
 
     /** 토론방 전체 조회 **/
+    @GetMapping
+    @Operation(summary = "토론방 전체 조회", description = "로그인한 후 토론방 전체를 조회할 수 있습니다.")
+    public ResponseEntity<Object> getAllDiscussions() {
+        List<DiscussionResponse> discussions = discussionService.getAllDiscussions();
+        return ResponseEntity.ok(discussions);
+    }
 
     /** 토론방 개별 조회 **/
-
+    @GetMapping("/{id}")
+    @Operation(summary = "토론방 개별 조회", description = "토론방 개별 조회를 하여 정보를 확인할 수 있습니다.")
+    public ResponseEntity<Object> getDiscussion(@PathVariable Long id){
+        DiscussionResponse discussion= discussionService.getDiscussionById(id);
+        return ResponseEntity.ok(discussion);
+    }
 }

--- a/src/main/java/com/fwaiya/princess_backend/controller/QuoteController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/QuoteController.java
@@ -1,0 +1,26 @@
+package com.fwaiya.princess_backend.controller;
+
+
+import com.fwaiya.princess_backend.dto.response.QuoteResponse;
+import com.fwaiya.princess_backend.service.QuoteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/quotes")
+@Tag(name = "08. 명언 관리", description = "랜덤으로 명언을 띄웁니다.")
+@RequiredArgsConstructor
+public class QuoteController {
+    private final QuoteService quoteService;
+
+    @GetMapping
+    public ResponseEntity<QuoteResponse> getQuote(){
+        QuoteResponse quote = quoteService.getQuote();
+        return ResponseEntity.ok(quote);
+    }
+}

--- a/src/main/java/com/fwaiya/princess_backend/controller/UserController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/UserController.java
@@ -1,43 +1,91 @@
 package com.fwaiya.princess_backend.controller;
 
-import com.fwaiya.princess_backend.global.api.ApiResponse;
-import com.fwaiya.princess_backend.global.api.SuccessCode;
+import com.fwaiya.princess_backend.domain.User;
+import com.fwaiya.princess_backend.dto.request.ProfileImageUpdateRequest;
+import com.fwaiya.princess_backend.dto.request.WantCreateRequest;
+import com.fwaiya.princess_backend.dto.response.UserInfoResponse;
+import com.fwaiya.princess_backend.global.constant.ProfileImageConstants;
 import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
 import com.fwaiya.princess_backend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /** * 사용자 정보 관리하는 컨트롤러 클래스 * 사용자 CRUD** @author yaaan7 * @since 2025-06-29 */
 @RestController
 @RequestMapping("/api/users")
-@Tag(name = "03. 사용자 관리", description = "사용자 CRUD API")
+@Tag(name = "03. 사용자 관리", description = "사용자 CRUD , 읽고 싶은 책 등록")
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
 
-    /** *닉네임 반환(로그인 테스트용)* *@param username(=userId)*/
-    @GetMapping("/nickname")
-    @Operation(summary = "닉네임 반환", description = "로그인한 사용자의 닉네임을 반환합니다.")
-    public ApiResponse<?> getNickname(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
-    ) {
-        String nickname = userService.getNickname(customUserDetails.getUsername());
-        return ApiResponse.onSuccess(SuccessCode.USER_NICKNAME_GET_SUCCESS, nickname);
-    }
-
     /** *회원탈퇴* *@param username(=userId)*/
     @DeleteMapping("/withdraw")
     @Operation(summary = "회원탈퇴", description = "로그인한 사용자의 회원탈퇴를 진행합니다.")
-    public ApiResponse<?> withdraw(
+    public ResponseEntity<Object> withdraw(
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
         userService.withdraw(customUserDetails.getUsername());
-        return ApiResponse.onSuccess(SuccessCode.USER_DELETE_SUCCESS, null);
+        return ResponseEntity.ok("회원 탈퇴 완료하였습니다");
+    }
+
+    /** *사용자 정보 조회*/
+    @GetMapping("/me")
+    @Operation(summary = "사용자 정보 조회", description = "로그인한 사용자의 정보를 조회합니다.")
+    public ResponseEntity<UserInfoResponse> getUserInfo(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        UserInfoResponse userInfoResponse = userService.getUserInfo(customUserDetails.getUsername());
+        return ResponseEntity.ok(userInfoResponse);
+    }
+
+    /** 읽고 싶은 책 등록 **/
+    @PostMapping("/want")
+    @Operation(summary = "읽고 싶은 책 등록", description = "로그인한 사용자가 읽고 싶은 책을 등록합니다.")
+    public ResponseEntity<String> createWant(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody WantCreateRequest wantCreateRequest
+    ){
+        User user = userService.findByUsername(customUserDetails.getUsername());
+        userService.createWant( wantCreateRequest,user );
+        return ResponseEntity.ok("읽고 싶은 책 등록 완료하였습니다.");
+    }
+
+    /** 읽고 싶은 책 삭제 **/
+    @DeleteMapping("/want/{wantID}")
+    @Operation(summary = "읽고 싶은 책 삭제", description = "로그인한 사용자의 특정 읽고 싶은 책을 삭제합니다.")
+    public ResponseEntity<Object> deleteWant(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @PathVariable Long wantID
+    ){
+        User user = userService.findByUsername(customUserDetails.getUsername());
+        userService.deleteWant(wantID, user);
+        return ResponseEntity.ok("삭제 완료하였습니다.");
+    }
+
+    /** 프로필 사진 수정**/
+    @PatchMapping("/profile")
+    @Operation(summary = "프로필 사진 변경", description = "로그인한 사용자의 프로필 사진을 8가지 중 하나로 변경합니다.")
+    public ResponseEntity<Object> updateProfile(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @Valid @RequestBody ProfileImageUpdateRequest profileImageUpdateRequest
+    ){
+        User user = userService.findByUsername(customUserDetails.getUsername());
+        userService.updateProfile(profileImageUpdateRequest.getImagePath(), user);
+
+        return ResponseEntity.ok("프로필 사진 변경 완료하였습니다.");
+    }
+
+    /** 프로필 사진 목록 조회 **/
+    @GetMapping("/profiles")
+    @Operation(summary = "프로필 사진 목록 조회", description="고정된 8개의 프로필 사진 목록을 반환합니다.")
+    public ResponseEntity<List<String>> getProfiles(){
+        return ResponseEntity.ok(ProfileImageConstants.FIXED_IMAGES);
     }
 }

--- a/src/main/java/com/fwaiya/princess_backend/domain/Book.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/Book.java
@@ -14,8 +14,8 @@ import com.fwaiya.princess_backend.domain.entity.BaseEntity; // createdAt, updat
 public class Book extends BaseEntity {
 
     @Id // 기본 키(PK) 설정
+    @Column(unique = true, nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY) // auto_increment 방식 사용
-    @Column(name = "book_id") // DB 컬럼명 지정
     private Long id;
 
     @Column(nullable = false, length = 200) // null 허용하지 않으며, 최대 길이 200자로 제한

--- a/src/main/java/com/fwaiya/princess_backend/domain/Book.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/Book.java
@@ -1,4 +1,39 @@
 package com.fwaiya.princess_backend.domain;
 
-public class Book {
+
+import jakarta.persistence.*;
+import lombok.*;
+import com.fwaiya.princess_backend.domain.entity.BaseEntity; // createdAt, updatedAt 포함된 상위 클래스
+
+@Entity // JPA가 이 클래스를 테이블과 매핑하도록 지정
+@Table(name = "book") // 실제 DB에 매핑될 테이블 이름을 "book"으로 지정
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 파라미터 없는 생성자를 생성하되, 외부에서 호출 못하도록 보호
+@AllArgsConstructor // 모든 필드 값을 매개변수로 받는 생성자 자동 생성
+@Builder // 빌더 패턴을 사용할 수 있게 설정
+public class Book extends BaseEntity {
+
+    @Id // 기본 키(PK) 설정
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // auto_increment 방식 사용
+    @Column(name = "book_id") // DB 컬럼명 지정
+    private Long id;
+
+    @Column(nullable = false, length = 200) // null 허용하지 않으며, 최대 길이 200자로 제한
+    private String title; // 책 제목
+
+    @Column(nullable = false, length = 100) // null 허용하지 않으며, 최대 길이 100자
+    private String author; // 저자 이름
+
+    @Column(length = 50) // 최대 길이 50자, null 허용됨
+    private String genre; // 책 장르 (예: 에세이, 소설, 자기계발 등)
+
+    @Column(name = "cover_image_url", length = 200)
+    private String coverImageUrl; // 책 표지 이미지 URL (S3 경로)
+
+    @Column(length = 200) // 최대 200자, null 허용
+    private String hashtags; // 책과 관련된 해시태그 문자열
+
+    // createdAt, updatedAt은 BaseEntity에서 상속받음
+    // createdAt → 엔티티 최초 저장 시 자동 기록
+    // updatedAt → 엔티티 수정 시 자동 갱신
 }

--- a/src/main/java/com/fwaiya/princess_backend/domain/Comment.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/Comment.java
@@ -2,14 +2,15 @@ package com.fwaiya.princess_backend.domain;
 
 import com.fwaiya.princess_backend.global.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 /** 독서 토론 방 댓글**/
 @Entity
 @Setter
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Comment extends BaseEntity {
 
     @Id

--- a/src/main/java/com/fwaiya/princess_backend/domain/Comment.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/Comment.java
@@ -1,4 +1,34 @@
 package com.fwaiya.princess_backend.domain;
 
-public class Comment {
+import com.fwaiya.princess_backend.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+/** 독서 토론 방 댓글**/
+@Entity
+@Setter
+@Getter
+public class Comment extends BaseEntity {
+
+    @Id
+    @Column(unique = true, nullable = false)
+    @Setter(AccessLevel.PRIVATE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 댓글(전체) id
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    // 토론 댓글과 독서 토론 연관관계 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "discussion_id")
+    private Discussion discussion;
+
+    // 토론 댓글과 회원 연관관계 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 }

--- a/src/main/java/com/fwaiya/princess_backend/domain/Discussion.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/Discussion.java
@@ -1,4 +1,46 @@
 package com.fwaiya.princess_backend.domain;
 
-public class Discussion {
+
+import com.fwaiya.princess_backend.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+/**독서 토론 방 엔티티 클래스**/
+@Entity
+@Setter
+@Getter
+public class Discussion extends BaseEntity {
+
+    @Id
+    @Column(unique = true, nullable = false)
+    @Setter(AccessLevel.PRIVATE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; //토론방 id
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob // 최대 65,535자
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Column(nullable = false)
+    private String status; // 삭제 시에 상태만 변경
+
+    // 독서토론과 책 연관관계 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    // 독서토론과 댓글 연관관계 (1:N)
 }

--- a/src/main/java/com/fwaiya/princess_backend/domain/Discussion.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/Discussion.java
@@ -1,22 +1,28 @@
 package com.fwaiya.princess_backend.domain;
 
 
+import com.fwaiya.princess_backend.dto.response.DiscussionResponse;
 import com.fwaiya.princess_backend.global.BaseEntity;
+import com.fwaiya.princess_backend.global.constant.DiscussionStatus;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**독서 토론 방 엔티티 클래스**/
 @Entity
 @Setter
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Discussion extends BaseEntity {
 
     @Id
-    @Column(unique = true, nullable = false)
+    @Column(name = "discussion_id", unique = true, nullable = false)
     @Setter(AccessLevel.PRIVATE)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; //토론방 id
@@ -25,17 +31,18 @@ public class Discussion extends BaseEntity {
     private String title;
 
     @Lob // 최대 65,535자
-    @Column(nullable = false)
     private String description;
 
+//    @Column(nullable = false)
+//    private LocalDate startDate;
+//
     @Column(nullable = false)
-    private LocalDate startDate;
+    //private LocalDate endDate;
+    private LocalDateTime endDate;
 
     @Column(nullable = false)
-    private LocalDate endDate;
-
-    @Column(nullable = false)
-    private String status; // 삭제 시에 상태만 변경
+    @Enumerated(EnumType.STRING)
+    private DiscussionStatus status = DiscussionStatus.ACTIVE; // 삭제 시에 상태만 변경
 
     // 독서토론과 책 연관관계 (N:1)
     @ManyToOne(fetch = FetchType.LAZY)
@@ -43,4 +50,17 @@ public class Discussion extends BaseEntity {
     private Book book;
 
     // 독서토론과 댓글 연관관계 (1:N)
+    @OneToMany(mappedBy = "discussion", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    // 상태 update
+    public void updateStatus(DiscussionStatus status){
+        this.status = status;
+    }
+
+    // 댓글 추가 메서드
+    public void addComment(Comment comment){
+        comments.add(comment);
+        comment.setDiscussion(this);
+    }
 }

--- a/src/main/java/com/fwaiya/princess_backend/domain/ReadingLog.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/ReadingLog.java
@@ -1,4 +1,46 @@
 package com.fwaiya.princess_backend.domain;
 
-public class ReadingLog {
+import com.fwaiya.princess_backend.global.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+
+/** 독서록 엔티티 **/
+@Entity
+@Setter
+@Getter
+public class ReadingLog extends BaseEntity {
+
+    @Id
+    @Column(unique = true, nullable = false)
+    @Setter(AccessLevel.PRIVATE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String OneLineReview;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    @Min(0)
+    @Max(5)
+    private int rating; // 별 0~5개
+
+    // 독서록과 책 연관관계 (1:1)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    // 독서록과 유저 연관관계 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 }
+

--- a/src/main/java/com/fwaiya/princess_backend/domain/User.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/User.java
@@ -1,18 +1,23 @@
 package com.fwaiya.princess_backend.domain;
 
 
+import com.fwaiya.princess_backend.global.BaseEntity;
+import com.fwaiya.princess_backend.global.constant.ReadingLevel;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.persistence.criteria.Order;
+import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 /** * 사용자 엔티티 클래스 ** @author yaaan7 @since 2025-06-26 */
+// id, username, nickname, password, imagePath, birthDate, readingLevel
 @Entity
 @Setter
 @Getter
-public class User {
+@NoArgsConstructor
+public class User extends BaseEntity {
 
     @Id
     @Column(unique = true, nullable = false)
@@ -24,7 +29,7 @@ public class User {
     @Column(unique = true, nullable = false)
     private String username;
 
-    // 8글자 제한
+    // 8글자 제한, 닉네임
     @Column(unique = true, nullable = false)
     private String nickname;
 
@@ -33,11 +38,46 @@ public class User {
 
     // 기본 값 수정하기
     @Column(nullable = false)
-    private String imagePath= "default.jpg";;
+    private String imagePath= "https://s3.bucket.com/profile/default2.png";;
 
     @Column(nullable = false)
     private LocalDate birthDate;
 
     @Column(nullable = false)
     private String role;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReadingLevel readingLevel = ReadingLevel.lower;
+
+    @Column(nullable = false)
+    private int readCount = 0;
+
+    // 유저와 댓글 연관관계 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    // 유저와 독서록 연관관계 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReadingLog> readingLogs = new ArrayList<>();
+
+    // 유저와 읽고 싶은 책 연관관계 (1:N)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WantToRead> wantToReads = new ArrayList<>();
+
+    // WantToRead와 양방향 편의 메서드
+    public void addWantToRead(WantToRead wantToRead) {
+        this.wantToReads.add(wantToRead);
+        wantToRead.setUser(this);
+    }
+
+    // 다음 레벨까지 몇 권 남았는지 계산
+    public int CountUntilNextLevel(){
+        return 5 - ( readCount % 5 );
+    }
+
+    // 프로필 사진 업데이트
+    public void updateImagePath(String newPath){
+        this.imagePath = newPath;
+    }
 }

--- a/src/main/java/com/fwaiya/princess_backend/domain/User.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/User.java
@@ -4,7 +4,6 @@ package com.fwaiya.princess_backend.domain;
 import com.fwaiya.princess_backend.global.BaseEntity;
 import com.fwaiya.princess_backend.global.constant.ReadingLevel;
 import jakarta.persistence.*;
-import jakarta.persistence.criteria.Order;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -53,9 +52,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private int readCount = 0;
 
-    // 유저와 댓글 연관관계 (1:N)
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
+    // 유저와 댓글 연관관계 (1:N) - 관리할 필요 x
+//    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Comment> comments = new ArrayList<>();
 
     // 유저와 독서록 연관관계 (1:N)
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/fwaiya/princess_backend/domain/WantToRead.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/WantToRead.java
@@ -1,4 +1,39 @@
 package com.fwaiya.princess_backend.domain;
 
-public class WantToRead {
+import com.fwaiya.princess_backend.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+/** 읽고 싶은 책 엔티티 **/
+@Entity
+@Setter
+@Getter
+public class WantToRead extends BaseEntity {
+
+    @Id
+    @Column(unique = true, nullable = false)
+    @Setter(AccessLevel.PRIVATE)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String bookTitle;
+
+    @Column(nullable = false)
+    private String author;
+
+    @Column(nullable = false)
+    private String genre;
+
+    @Lob
+    @Column(nullable = false)
+    private String memo;
+
+    // 읽고 싶은 책과 유저 연관관계 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
 }

--- a/src/main/java/com/fwaiya/princess_backend/domain/entity/BaseEntity.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/entity/BaseEntity.java
@@ -1,4 +1,26 @@
 package com.fwaiya.princess_backend.domain.entity;
 
-public class BaseEntity {
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass // 이 클래스를 상속받는 클래스들이 공통으로 필드를 가지게 함
+@EntityListeners(AuditingEntityListener.class) // 생성/수정 시간을 자동으로 채워줌
+@Getter
+public abstract class BaseEntity {
+
+    @CreationTimestamp // 최초 생성 시간 자동 기록
+    @Column(updatable = false) // 업데이트 시에는 변경되지 않도록 설정
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp // 매번 업데이트 시 자동 갱신
+    @Column(insertable = false) // 생성 시에는 무시되도록 설정
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/fwaiya/princess_backend/dto/BookDto.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/BookDto.java
@@ -1,0 +1,47 @@
+package com.fwaiya.princess_backend.dto;
+
+import com.fwaiya.princess_backend.domain.Book;
+import lombok.*;
+
+// BookDto는 클라이언트와 Book 데이터를 주고받기 위한 전용 객체
+// 외부 노출 시에는 DTO를 통해 안전하고 유연하게 데이터를 주고받음
+
+@Getter
+@Setter
+@NoArgsConstructor // 기본 생성자 자동 생성
+@AllArgsConstructor // 전체 필드를 인자로 받는 생성자 자동 생성
+@Builder // 빌더 패턴 사용을 위한 어노테이션
+public class BookDto {
+
+    private Long id; // Book 엔티티의 기본키 (book_id)
+    private String title; // 책 제목
+    private String author; // 저자
+    private String genre; // 장르 (소설, 에세이, 자기계발 등)
+    private String coverImageUrl; // 책 표지 이미지 URL (S3 경로)
+    private String hashtags; // 해시태그 문자열 (예: "#고전#추천")
+
+    // Entity → DTO 변환 메서드
+    // 주로 Controller나 Service에서 DB 조회 결과를 클라이언트에게 반환할 때 사용
+    public static BookDto fromEntity(Book book) {
+        return BookDto.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .genre(book.getGenre())
+                .coverImageUrl(book.getCoverImageUrl())
+                .hashtags(book.getHashtags())
+                .build();
+    }
+
+    //  DTO → Entity 변환 메서드
+    //  주로 클라이언트에서 전달받은 데이터를 DB에 저장할 때 사용
+    public Book toEntity() {
+        return Book.builder()
+                .title(this.title)
+                .author(this.author)
+                .genre(this.genre)
+                .coverImageUrl(this.coverImageUrl)
+                .hashtags(this.hashtags)
+                .build();
+    }
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/CommentCreateRequest.java
@@ -1,0 +1,19 @@
+package com.fwaiya.princess_backend.dto.request;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Lob;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentCreateRequest {
+
+    @Lob
+    @NotBlank(message = "댓글 내용 입력은 필수입니다.")
+    private String content;
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/DiscussionCreateRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/DiscussionCreateRequest.java
@@ -1,0 +1,21 @@
+package com.fwaiya.princess_backend.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiscussionCreateRequest {
+
+    private String title; // 토론방 제목
+
+    private String description; // 토론방 제목
+
+    @NotBlank(message = "책 제목은 필수입니다.")
+    private String bookTitle;
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/ProfileImageUpdateRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/ProfileImageUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.fwaiya.princess_backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProfileImageUpdateRequest {
+    @NotBlank
+    @Schema(description = "프로필 사진 경로", example = "https://s3.bucket.com/profile/default1.png")
+    private String imagePath;
+}
+

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/WantCreateRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/WantCreateRequest.java
@@ -1,0 +1,26 @@
+package com.fwaiya.princess_backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WantCreateRequest {
+
+    @NotBlank(message = "책 제목은 필수입니다.")
+    private String bookTitle;
+
+    @NotBlank(message = "저자는 필수입니다.")
+    private String author;
+
+    @NotBlank(message = "장르는 필수입니다.")
+    private String genre;
+
+    @NotBlank(message = "메모는 필수입니다.")
+    private String memo;
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/WantCreateRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/WantCreateRequest.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/CommentResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/CommentResponse.java
@@ -8,19 +8,18 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class CommentResponse {
-    // content,user의 프로필, 닉네임, 리딩레벨
-    // lob인데 걍 이렇게 해도 되나
+    // 댓글 content,user의 프로필, 닉네임, 리딩레벨
     public String content;
     public String nickname;
     public String imagePath;
-    public ReadingLevel readingLevel;
+    public String readingLevel;
 
     public static CommentResponse from(Comment comment) {
         return new CommentResponse(
                 comment.getContent(),
                 comment.getUser().getNickname(),
                 comment.getUser().getImagePath(),
-                comment.getUser().getReadingLevel()
+                comment.getUser().getReadingLevel().getKoreanName()
         );
     }
 }

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/CommentResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/CommentResponse.java
@@ -1,0 +1,26 @@
+package com.fwaiya.princess_backend.dto.response;
+
+import com.fwaiya.princess_backend.domain.Comment;
+import com.fwaiya.princess_backend.global.constant.ReadingLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentResponse {
+    // content,user의 프로필, 닉네임, 리딩레벨
+    // lob인데 걍 이렇게 해도 되나
+    public String content;
+    public String nickname;
+    public String imagePath;
+    public ReadingLevel readingLevel;
+
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(
+                comment.getContent(),
+                comment.getUser().getNickname(),
+                comment.getUser().getImagePath(),
+                comment.getUser().getReadingLevel()
+        );
+    }
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/DiscussionResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/DiscussionResponse.java
@@ -1,0 +1,23 @@
+package com.fwaiya.princess_backend.dto.response;
+
+
+import com.fwaiya.princess_backend.domain.Discussion;
+import com.fwaiya.princess_backend.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DiscussionResponse {
+    private String bookTitle;
+    private String bookAuthor;
+    private String bookCoverImageUrl;
+
+    public static DiscussionResponse from(Discussion discussion) {
+        return new DiscussionResponse(
+                discussion.getBook().getTitle(),
+                discussion.getBook().getAuthor(),
+                discussion.getBook().getCoverImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/QuoteResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/QuoteResponse.java
@@ -1,0 +1,11 @@
+package com.fwaiya.princess_backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuoteResponse {
+    private String message;
+    private String author;
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/UserInfoResponse.java
@@ -1,0 +1,38 @@
+package com.fwaiya.princess_backend.dto.response;
+
+import com.fwaiya.princess_backend.domain.ReadingLog;
+import com.fwaiya.princess_backend.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/** User Service -> Controller , Controller -> Client **/
+@Getter
+@AllArgsConstructor
+public class UserInfoResponse {
+    private String nickname;
+    private String imagePath;
+    private LocalDate birthDate;
+    private String readingLevel;
+    private int untilNextLevel;
+    private List<ReadingLog> readingLogs;
+    //private List<ReadingLogDto> readingLogs;
+    private List<WantCreateResponse> wantToReads;
+
+    // User -> UserInfoResponse로 변환
+    public static UserInfoResponse from(User user){
+        return new UserInfoResponse(
+                user.getNickname(),
+                user.getImagePath(),
+                user.getBirthDate(),
+                user.getReadingLevel().getKoreanName(),
+                user.CountUntilNextLevel(),
+                user.getReadingLogs(),
+                user.getWantToReads().stream()
+                        .map(WantCreateResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/WantCreateResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/WantCreateResponse.java
@@ -1,0 +1,32 @@
+package com.fwaiya.princess_backend.dto.response;
+
+import com.fwaiya.princess_backend.domain.WantToRead;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/** 읽고 싶은 책 응답 DTO **/
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class WantCreateResponse {
+    private Long id;
+    private String bookTitle;
+    private String author;
+    private String genre;
+    private String memo;
+
+    // DTO로 변환
+    public static WantCreateResponse from(WantToRead wantToRead) {
+        return new WantCreateResponse(
+                wantToRead.getId(),
+                wantToRead.getBookTitle(),
+                wantToRead.getAuthor(),
+                wantToRead.getGenre(),
+                wantToRead.getMemo()
+        );
+    }
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/global/SecurityConfig.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/SecurityConfig.java
@@ -80,7 +80,7 @@ public class SecurityConfig {
                         ).permitAll()
 
                         // admin 페이지엔 role이 관리자일 때만 접근 가능
-                        // http.requestMatchers("/admin").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/discussions").hasRole("ADMIN")
                         // 외엔 로그인한 사용자만 접근 가능
                         .anyRequest().authenticated());
         http

--- a/src/main/java/com/fwaiya/princess_backend/global/api/ErrorCode.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/api/ErrorCode.java
@@ -24,7 +24,11 @@ public enum ErrorCode implements BaseCode { // 실패
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT_4011", "Authorization 헤더가 없거나 형식이 올바르지 않습니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT_4012", "토큰 유효기간이 만료되었습니다."),
     TOKEN_INVALID(HttpStatus.FORBIDDEN, "JWT_4031", "유효하지 않은 토큰입니다."),
-    TOKEN_NO_AUTH(HttpStatus.FORBIDDEN, "JWT_4031", "권한 정보가 없는 토큰입니다.");
+    TOKEN_NO_AUTH(HttpStatus.FORBIDDEN, "JWT_4031", "권한 정보가 없는 토큰입니다."),
+
+    // Profile
+    INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "USER_4001", "허용되지 않은 프로필 이미지입니다."),
+    WANT_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_4003", "해당 읽고 싶은 책 정보를 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/fwaiya/princess_backend/global/api/SuccessCode.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/api/SuccessCode.java
@@ -16,7 +16,12 @@ public enum SuccessCode implements BaseCode { // 성공
     USER_LOGIN_SUCCESS(HttpStatus.CREATED, "USER_201", "로그인이 완료되었습니다."),
     USER_DELETE_SUCCESS(HttpStatus.OK, "USER_200", "회원탈퇴가 완료되었습니다."),
 
-    USER_NICKNAME_GET_SUCCESS(HttpStatus.OK, "USER_200", "닉네임 조회가 완료되었습니다.");
+    USER_INFO_GET_SUCCESS(HttpStatus.OK, "USER_2001", "회원정보 조회가 완료되었습니다."),
+    USER_WANT_POST_SUCCESS(HttpStatus.OK, "USER_2002", "읽고 싶은 책 등록이 완료되었습니다."),
+    USER_WANT_DELETE_SUCCESS(HttpStatus.OK, "USER_2003", "읽고 싶은 책 삭제가 완료되었습니다."),
+    USER_PROFILE_IMAGE_UPDATE_SUCCESS(HttpStatus.OK, "USER_2004", "프로필 이미지 변경이 완료되었습니다."),
+    USER_PROFILE_IMAGE_LIST_GET_SUCCESS(HttpStatus.OK, "USER_2005", "프로필 이미지 목록 조회 성공");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/fwaiya/princess_backend/global/constant/DiscussionStatus.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/constant/DiscussionStatus.java
@@ -1,0 +1,5 @@
+package com.fwaiya.princess_backend.global.constant;
+
+public enum DiscussionStatus {
+    ACTIVE, CANCELLED
+}

--- a/src/main/java/com/fwaiya/princess_backend/global/constant/Genre.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/constant/Genre.java
@@ -1,4 +1,7 @@
 package com.fwaiya.princess_backend.global.constant;
 
+// DTO 에서 변환
+// 자기계발/소설/경제/인문학/에세이/만화/종교/과학/사회/시
 public enum Genre {
+    improvement, fiction, economics, humanities, essay, comics, religion, science, society, poetry
 }

--- a/src/main/java/com/fwaiya/princess_backend/global/constant/ProfileImageConstants.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/constant/ProfileImageConstants.java
@@ -1,0 +1,11 @@
+package com.fwaiya.princess_backend.global.constant;
+
+import java.util.List;
+
+public class ProfileImageConstants {
+    public static final List<String> FIXED_IMAGES = List.of(
+            "https://s3.bucket.com/profile/default1.png",
+            "https://s3.bucket.com/profile/default2.png",
+            "https://s3.bucket.com/profile/default3.png"
+                );
+}

--- a/src/main/java/com/fwaiya/princess_backend/global/constant/ReadingLevel.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/constant/ReadingLevel.java
@@ -1,6 +1,6 @@
 package com.fwaiya.princess_backend.global.constant;
 
-import lombok.AllArgsConstructor;
+
 import lombok.Getter;
 
 // DTO에서 한국어로 변환해서 처리

--- a/src/main/java/com/fwaiya/princess_backend/global/constant/ReadingLevel.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/constant/ReadingLevel.java
@@ -1,4 +1,25 @@
 package com.fwaiya.princess_backend.global.constant;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// DTO에서 한국어로 변환해서 처리
+// 하층민/평민/상인/귀족/공주
+@Getter
 public enum ReadingLevel {
+    lower("하층민"),
+    commoner("평민"),
+    merchant("상인"),
+    aristocrat("귀족"),
+    princess("공주");
+
+    private final String koreanName;
+
+    private ReadingLevel(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
 }

--- a/src/main/java/com/fwaiya/princess_backend/login/controller/JoinController.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/controller/JoinController.java
@@ -1,17 +1,14 @@
 package com.fwaiya.princess_backend.login.controller;
 
-import com.fwaiya.princess_backend.global.api.ApiResponse;
-import com.fwaiya.princess_backend.global.api.ErrorCode;
-import com.fwaiya.princess_backend.global.api.SuccessCode;
-import com.fwaiya.princess_backend.global.exception.GeneralException;
 import com.fwaiya.princess_backend.login.dto.JoinRequestDto;
+import com.fwaiya.princess_backend.login.dto.JoinResponseDto;
 import com.fwaiya.princess_backend.login.service.JoinService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,19 +23,15 @@ public class JoinController {
 
     @Operation(summary="회원가입", description = "사용자 정보를 받아 회원가입을 진행합니다.")
     @PostMapping("/join")
-    public ApiResponse<?> joinProcess(JoinRequestDto joinRequestDto) {
-
-        log.info("회원가입 요청 수신");
-        try {
-            joinService.joinProcess(joinRequestDto);
-            log.info("회원가입 성공");
-            return ApiResponse.onSuccess(SuccessCode.USER_JOIN_SUCCESS,"");
-        } catch (GeneralException e) {
-            log.error("회원가입 중 예외 발생: {}", e.getReason().getMessage());
-            throw e;
-        } catch (Exception e){
-            log.error("알 수 없는 예외 발생: {}", e.getMessage());
-            throw new GeneralException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
+    public ResponseEntity<String> joinProcess(JoinRequestDto joinRequestDto) {
+            JoinResponseDto response = joinService.joinProcess(joinRequestDto);
+            return ResponseEntity.ok("회원 가입을 성공하였습니다");
     }
+//        } catch (GeneralException e) {
+//            log.error("회원가입 중 예외 발생: {}", e.getReason().getMessage());
+//            throw e;
+//        } catch (Exception e){
+//            log.error("알 수 없는 예외 발생: {}", e.getMessage());
+//            throw new GeneralException(ErrorCode.INTERNAL_SERVER_ERROR);
+//        }
 }

--- a/src/main/java/com/fwaiya/princess_backend/login/controller/JoinController.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/controller/JoinController.java
@@ -21,17 +21,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class JoinController {
     private final JoinService joinService;
 
-    @Operation(summary="회원가입", description = "사용자 정보를 받아 회원가입을 진행합니다.")
+    @Operation(summary = "회원가입", description = "사용자 정보를 받아 회원가입을 진행합니다.")
     @PostMapping("/join")
     public ResponseEntity<String> joinProcess(JoinRequestDto joinRequestDto) {
-            JoinResponseDto response = joinService.joinProcess(joinRequestDto);
-            return ResponseEntity.ok("회원 가입을 성공하였습니다");
+        JoinResponseDto response = joinService.joinProcess(joinRequestDto);
+        return ResponseEntity.ok("회원 가입을 성공하였습니다");
     }
-//        } catch (GeneralException e) {
-//            log.error("회원가입 중 예외 발생: {}", e.getReason().getMessage());
-//            throw e;
-//        } catch (Exception e){
-//            log.error("알 수 없는 예외 발생: {}", e.getMessage());
-//            throw new GeneralException(ErrorCode.INTERNAL_SERVER_ERROR);
-//        }
 }

--- a/src/main/java/com/fwaiya/princess_backend/login/controller/LoginController.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/controller/LoginController.java
@@ -1,8 +1,5 @@
 package com.fwaiya.princess_backend.login.controller;
 
-import com.fwaiya.princess_backend.global.api.ApiResponse;
-import com.fwaiya.princess_backend.global.api.ErrorCode;
-import com.fwaiya.princess_backend.global.api.SuccessCode;
 import com.fwaiya.princess_backend.login.dto.LoginRequestDto;
 import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
 import com.fwaiya.princess_backend.login.jwt.JWTUtil;
@@ -10,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -34,7 +32,7 @@ public class LoginController {
 
     @PostMapping("/swagger")
     @Operation(summary = "Swagger 전용 로그인", description = " userId, password로 JWT 토큰을 발급받습니다.")
-    public ApiResponse<String> login(@RequestBody LoginRequestDto dto) {
+    public ResponseEntity<String> login(@RequestBody LoginRequestDto dto) {
         try {
             UsernamePasswordAuthenticationToken token =
                     new UsernamePasswordAuthenticationToken(dto.getUserId(), dto.getPassword());
@@ -44,19 +42,17 @@ public class LoginController {
 
             String jwt = jwtUtil.createJwt(userDetails.getUsername(), userDetails.getAuthorities().iterator().next().getAuthority());
 
-            return ApiResponse.onSuccess(SuccessCode.USER_LOGIN_SUCCESS, jwt);
+            return ResponseEntity.ok(jwt);
 
         } catch (UsernameNotFoundException e) {
             log.warn("Swagger 로그인 실패 - 존재하지 않는 아이디: {}", dto.getUserId());
-            return ApiResponse.onFailure(ErrorCode.ID_PASSWORD_MISMATCH, null);
-
+            return ResponseEntity.ok("아이디나 비밀번호가 일치하지 않습니다");
         } catch (BadCredentialsException e) {
             log.warn("Swagger 로그인 실패 - 비밀번호 오류: {}", dto.getUserId());
-            return ApiResponse.onFailure(ErrorCode.ID_PASSWORD_MISMATCH, null);
-
+            return ResponseEntity.ok("아이디나 비밀번호가 일치하지 않습니다");
         } catch (AuthenticationException e) {
             log.warn("Swagger 로그인 실패 - 기타 인증 오류: {}", e.getMessage());
-            return ApiResponse.onFailure(ErrorCode.ID_PASSWORD_MISMATCH, null);
+            return ResponseEntity.ok("아이디나 비밀번호가 일치하지 않습니다");
         }
     }
 }

--- a/src/main/java/com/fwaiya/princess_backend/login/dto/JoinRequestDto.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/dto/JoinRequestDto.java
@@ -1,7 +1,7 @@
 package com.fwaiya.princess_backend.login.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,15 +12,19 @@ import java.time.LocalDate;;
 @Schema(description = "로그인 요청 DTO")
 public class JoinRequestDto {
 
+    @NotBlank(message = "Id는 필수입니다.")
     @Schema(description = "사용자 ID", example = "1234@naver.com")
     private String userId;
 
+    @NotBlank(message = "닉네임은 필수입니다.")
     @Schema(description = "닉네임", example = "yaaan")
     private String nickname;
 
+    @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "비밀번호", example = "yaaan7")
     private String password;
 
+    @NotBlank(message = "생년월일은 필수입니다.")
     @Schema(description = "생년월일", example = "2025-01-01")
     private LocalDate birthDate;
 

--- a/src/main/java/com/fwaiya/princess_backend/login/dto/JoinResponseDto.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/dto/JoinResponseDto.java
@@ -1,0 +1,16 @@
+package com.fwaiya.princess_backend.login.dto;
+
+import com.fwaiya.princess_backend.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JoinResponseDto {
+    private String username;
+    private String nickname;
+
+    public static JoinResponseDto from(User user) {
+        return new JoinResponseDto(user.getUsername(), user.getNickname());
+    }
+}

--- a/src/main/java/com/fwaiya/princess_backend/login/jwt/JWTFilter.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/jwt/JWTFilter.java
@@ -1,10 +1,7 @@
 package com.fwaiya.princess_backend.login.jwt;
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fwaiya.princess_backend.domain.User;
-import com.fwaiya.princess_backend.global.api.ApiResponse;
-import com.fwaiya.princess_backend.global.api.ErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/fwaiya/princess_backend/login/jwt/LoginFilter.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/jwt/LoginFilter.java
@@ -1,8 +1,5 @@
 package com.fwaiya.princess_backend.login.jwt;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fwaiya.princess_backend.global.api.ApiResponse;
-import com.fwaiya.princess_backend.global.api.ErrorCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,13 +10,10 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -58,9 +52,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
 
-        ApiResponse<?> result;
-
+        /*ApiResponse<?> result;
         result = ApiResponse.onFailure(ErrorCode.ID_PASSWORD_MISMATCH, null);
+
 
         ObjectMapper objectMapper = new ObjectMapper();
         response.getWriter().write(objectMapper.writeValueAsString(result));
@@ -72,7 +66,21 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             log.info("로그인 실패: 비밀번호 오류 - {}", failed.getMessage());
         } else {
             log.info("로그인 실패: 기타 인증 실패 - {}", failed.getMessage());
+        }*/
+
+        String message;
+
+        if (failed instanceof UsernameNotFoundException) {
+            message = "존재하지 않는 사용자입니다.";
+        } else if (failed instanceof BadCredentialsException) {
+            message = "아이디 또는 비밀번호가 일치하지 않습니다.";
+        } else {
+            message = "로그인에 실패했습니다.";
         }
+
+        response.getWriter().write(message);
+        log.warn("로그인 실패: {}", message);
+
     }
 
 }

--- a/src/main/java/com/fwaiya/princess_backend/login/service/CustomUserDetailsService.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/service/CustomUserDetailsService.java
@@ -1,8 +1,6 @@
 package com.fwaiya.princess_backend.login.service;
 
 import com.fwaiya.princess_backend.domain.User;
-import com.fwaiya.princess_backend.global.api.ErrorCode;
-import com.fwaiya.princess_backend.global.exception.GeneralException;
 import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
 import com.fwaiya.princess_backend.repository.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/fwaiya/princess_backend/login/service/JoinService.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/service/JoinService.java
@@ -43,7 +43,8 @@ public class JoinService {
         user.setNickname(nickname);
         user.setPassword(bCryptPasswordEncoder.encode(password));
         user.setBirthDate(birthDate);
-        user.setRole("ROLE_USER");
+        String role = username.equals("1234@naver.com") ? "ROLE_ADMIN" : "ROLE_USER";
+        user.setRole(role);
 
         userRepository.save(user);
 

--- a/src/main/java/com/fwaiya/princess_backend/login/service/JoinService.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/service/JoinService.java
@@ -1,11 +1,10 @@
 package com.fwaiya.princess_backend.login.service;
 
 import com.fwaiya.princess_backend.domain.User;
-import com.fwaiya.princess_backend.global.api.ApiResponse;
 import com.fwaiya.princess_backend.global.api.ErrorCode;
-import com.fwaiya.princess_backend.global.api.SuccessCode;
 import com.fwaiya.princess_backend.global.exception.GeneralException;
 import com.fwaiya.princess_backend.login.dto.JoinRequestDto;
+import com.fwaiya.princess_backend.login.dto.JoinResponseDto;
 import com.fwaiya.princess_backend.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +21,7 @@ public class JoinService {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Transactional
-    public ApiResponse<?> joinProcess(JoinRequestDto joinRequestDto) {
+    public JoinResponseDto joinProcess(JoinRequestDto joinRequestDto) {
 
         String username = joinRequestDto.getUserId();
         String nickname = joinRequestDto.getNickname();
@@ -31,16 +30,15 @@ public class JoinService {
 
         Boolean isExist1 = userRepository.existsByUsername(username);
         if (isExist1) {
-            throw new GeneralException(ErrorCode.ALREADY_USED_USERID);
+            throw new IllegalStateException("이미 존재하는 ID 입니다.");
         }
 
         Boolean isExist2 = userRepository.existsByNickname(nickname);
         if (isExist2) {
-            throw new GeneralException(ErrorCode.ALREADY_USED_NICKNAME);
+            throw new IllegalStateException("이미 존재하는 닉네임 입니다.");
         }
 
         User user = new User();
-
         user.setUsername(username);
         user.setNickname(nickname);
         user.setPassword(bCryptPasswordEncoder.encode(password));
@@ -49,7 +47,7 @@ public class JoinService {
 
         userRepository.save(user);
 
-        return ApiResponse.onSuccess(SuccessCode.USER_JOIN_SUCCESS, "회원가입이 완료되었습니다.");
+        return JoinResponseDto.from(user);
     }
 
 }

--- a/src/main/java/com/fwaiya/princess_backend/repository/BookRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/BookRepository.java
@@ -1,0 +1,19 @@
+package com.fwaiya.princess_backend.repository;
+
+import com.fwaiya.princess_backend.domain.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+// Book 엔티티에 대한 DB 접근을 담당하는 JPA Repository 인터페이스
+// JpaRepository<Book, Long>을 상속받아 기본 CRUD 기능을 자동으로 제공
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
+
+    // 기본적으로 다음과 같은 메서드를 자동으로 제공함:
+    // - findAll() : 전체 목록 조회
+    // - findById(Long id) : ID로 단건 조회
+    // - save(Book book) : 삽입 또는 수정
+    // - deleteById(Long id) : 삭제
+    // - existsById(Long id) : 존재 여부 확인
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/repository/BookRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/BookRepository.java
@@ -1,13 +1,18 @@
 package com.fwaiya.princess_backend.repository;
 
 import com.fwaiya.princess_backend.domain.Book;
+import com.fwaiya.princess_backend.domain.Discussion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 // Book 엔티티에 대한 DB 접근을 담당하는 JPA Repository 인터페이스
 // JpaRepository<Book, Long>을 상속받아 기본 CRUD 기능을 자동으로 제공
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
+
+    Optional<Book> findByTitle(String title);
 
     // 기본적으로 다음과 같은 메서드를 자동으로 제공함:
     // - findAll() : 전체 목록 조회

--- a/src/main/java/com/fwaiya/princess_backend/repository/CommentRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.fwaiya.princess_backend.repository;
+
+import com.fwaiya.princess_backend.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/fwaiya/princess_backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/DiscussionRepository.java
@@ -1,0 +1,7 @@
+package com.fwaiya.princess_backend.repository;
+
+import com.fwaiya.princess_backend.domain.Discussion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
+}

--- a/src/main/java/com/fwaiya/princess_backend/repository/DiscussionRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/DiscussionRepository.java
@@ -1,7 +1,17 @@
 package com.fwaiya.princess_backend.repository;
 
 import com.fwaiya.princess_backend.domain.Discussion;
+import com.fwaiya.princess_backend.global.constant.DiscussionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
+
+    List<Discussion> findAllByStatus(DiscussionStatus status);
+    Optional<Discussion> findByIdAndStatus(Long id, DiscussionStatus status);
+    List<Discussion> findByStatusAndEndDateBefore(DiscussionStatus status, LocalDateTime dateTime);
+
 }

--- a/src/main/java/com/fwaiya/princess_backend/repository/WantToReadRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/WantToReadRepository.java
@@ -1,0 +1,11 @@
+package com.fwaiya.princess_backend.repository;
+
+import com.fwaiya.princess_backend.domain.WantToRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WantToReadRepository extends JpaRepository<WantToRead, Long> {
+
+    Optional<WantToRead> findByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/com/fwaiya/princess_backend/service/BookService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/BookService.java
@@ -1,0 +1,77 @@
+package com.fwaiya.princess_backend.service;
+
+import com.fwaiya.princess_backend.domain.Book;
+import com.fwaiya.princess_backend.dto.BookDto;
+import com.fwaiya.princess_backend.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+//  BookService는 책 등록, 조회, 수정, 삭제와 같은 비즈니스 로직을 처리하는 서비스 계층
+// Repository를 통해 DB에 접근, Controller와 Repository 사이에서 중간 역할을 수행
+
+@Service // 스프링이 이 클래스를 서비스 컴포넌트로 인식하게 함
+@RequiredArgsConstructor // 생성자를 통한 의존성 주입 자동 처리
+public class BookService {
+
+    private final BookRepository bookRepository;
+
+    // 책 등록 메서드
+    //  BookDto를 Book 엔티티로 변환한 후, DB에 저장
+    public Book saveBook(BookDto dto) {
+        Book newBook = dto.toEntity();
+        return bookRepository.save(newBook);
+    }
+
+
+    // 전체 책 목록 조회
+    // Repository에서 모든 Book 엔티티를 조회한 후, 클라이언트에 반환하기 위해 DTO 리스트로 변환
+    public List<BookDto> getAllBooks() {
+        return bookRepository.findAll().stream()
+                .map(BookDto::fromEntity) // 각 Book → BookDto로 변환
+                .collect(Collectors.toList());
+    }
+
+
+    // 특정 책 조회
+    // 해당 ID에 해당하는 Book 엔티티가 없으면 예외 발생
+    // 있으면 DTO로 변환 후 반환
+    public BookDto getBook(Long id) {
+        Book book = bookRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 책입니다. ID: " + id));
+        return BookDto.fromEntity(book);
+    }
+
+
+    // 책 정보 수정
+    // 기존 데이터를 조회한 뒤, 전달된 값을 기반으로 새 Book 객체를 만듦
+    public Book updateBook(Long id, BookDto dto) {
+        Book original = bookRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 책입니다. ID: " + id));
+
+        Book updated = Book.builder()
+                .id(original.getId()) // ID는 유지
+                .title(dto.getTitle())
+                .author(dto.getAuthor())
+                .genre(dto.getGenre())
+                .coverImageUrl(dto.getCoverImageUrl())
+                .hashtags(dto.getHashtags())
+                .build();
+
+        return bookRepository.save(updated); // save로 업데이트 처리
+    }
+
+
+    // 책 삭제
+    // 해당 책이 존재하지 않으면 예외 발생
+    // 존재하면 삭제
+    public void deleteBook(Long id) {
+        if (!bookRepository.existsById(id)) {
+            throw new IllegalArgumentException("삭제할 책이 존재하지 않습니다. ID: " + id);
+        }
+        bookRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/fwaiya/princess_backend/service/CommentService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/CommentService.java
@@ -1,14 +1,51 @@
 package com.fwaiya.princess_backend.service;
 
+import com.fwaiya.princess_backend.domain.Comment;
+import com.fwaiya.princess_backend.domain.Discussion;
+import com.fwaiya.princess_backend.domain.User;
+import com.fwaiya.princess_backend.dto.request.CommentCreateRequest;
+import com.fwaiya.princess_backend.dto.response.CommentResponse;
+import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
+import com.fwaiya.princess_backend.repository.CommentRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
+    private final CommentRepository commentRepository;
+    private final DiscussionService discussionService;
+    private final UserService userService;
 
     /** 댓글 등록 기능**/
+    @Transactional
+    public void createComment(Long discussionId, CommentCreateRequest request, CustomUserDetails customUserDetails) {
+        // 유저 확인
+        User user = userService.findByUsername(customUserDetails.getUsername());
+        // 토론방 id 확인
+        Discussion discussion = discussionService.getActiveDiscussion(discussionId);
+
+        Comment comment = Comment.builder()
+                .discussion(discussion)
+                .user(user)
+                .content(request.getContent())
+                .build();
+        // 토론방의 댓글 리스트로 등록
+        discussion.addComment(comment);
+        commentRepository.save(comment);
+    }
 
     /** 댓글 목록 조회 기능**/
+    @Transactional
+    public List<CommentResponse> getAllComments(Long discussionId){
+        Discussion discussion = discussionService.getActiveDiscussion(discussionId);
+        return discussion.getComments().stream()
+                .map(CommentResponse::from)
+                .collect(Collectors.toList());
+    }
 
 }

--- a/src/main/java/com/fwaiya/princess_backend/service/CommentService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/CommentService.java
@@ -1,0 +1,14 @@
+package com.fwaiya.princess_backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    /** 댓글 등록 기능**/
+
+    /** 댓글 목록 조회 기능**/
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/service/DiscussionService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/DiscussionService.java
@@ -1,17 +1,89 @@
 package com.fwaiya.princess_backend.service;
 
+import com.fwaiya.princess_backend.domain.Book;
+import com.fwaiya.princess_backend.domain.Discussion;
+import com.fwaiya.princess_backend.dto.request.DiscussionCreateRequest;
+import com.fwaiya.princess_backend.dto.response.DiscussionResponse;
+import com.fwaiya.princess_backend.global.BaseEntity;
+import com.fwaiya.princess_backend.global.constant.DiscussionStatus;
+import com.fwaiya.princess_backend.global.exception.GeneralException;
+import com.fwaiya.princess_backend.repository.BookRepository;
+import com.fwaiya.princess_backend.repository.DiscussionRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class DiscussionService {
+    private final DiscussionRepository discussionRepository;
+    private final BookRepository bookRepository;
+
+    public Discussion getActiveDiscussion(Long discussionId){
+        return discussionRepository.findByIdAndStatus(discussionId, DiscussionStatus.ACTIVE)
+                .orElseThrow(() -> new IllegalArgumentException("활성화된 토론방이 존재하지 않습니다."));
+    }
 
     /** 토론방 전체 조회 **/
+    @Transactional
+    public List<DiscussionResponse> getAllDiscussions() {
+        return discussionRepository.findAllByStatus(DiscussionStatus.ACTIVE).stream()
+                .map(DiscussionResponse::from)
+                .collect(Collectors.toList());
+    }
+
 
     /** 토론방 개별 조회 **/
+    @Transactional
+    public DiscussionResponse getDiscussionById(Long discussionId) {
+
+        Discussion discussion = getActiveDiscussion(discussionId);
+
+        return DiscussionResponse.from(discussion);
+    }
+
 
     /** 토론방 등록 **/
+    @Transactional
+    public DiscussionResponse createDiscussion(DiscussionCreateRequest request) {
+        // 책 제목 조회
+        Book book = bookRepository.findByTitle(request.getBookTitle())
+                .orElseThrow(() -> new IllegalArgumentException("해당 제목의 책이 존재하지 않습니다: " + request.getBookTitle()));
+
+        Discussion discussion = Discussion.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .book(book)
+                .status(DiscussionStatus.ACTIVE)
+                //.endDate(LocalDateTime.now().plusWeeks(1))
+                .endDate(LocalDateTime.now().plusMinutes(1))
+                .build();
+
+        Discussion saved = discussionRepository.save(discussion);
+        return DiscussionResponse.from(saved);
+    }
 
     /** 토론방 삭제 **/
+    @Scheduled(fixedRate = 60000)
+    @Transactional
+    public void updateDiscussionStatus(){
+
+        // 활성화 되어 있고 일주일 전에 생성된 주문 찾기
+        // 정확히 일주일 전이 아닌 날짜만 보게끔 고쳐보자
+        List<Discussion> expiredDiscussions = discussionRepository.findByStatusAndEndDateBefore(
+                DiscussionStatus.ACTIVE,
+                LocalDateTime.now()
+        );
+
+        // 상태 'CANCELED'로 변경
+        for (Discussion discussion : expiredDiscussions) {
+            discussion.updateStatus(DiscussionStatus.CANCELLED);
+        }
+    }
 }

--- a/src/main/java/com/fwaiya/princess_backend/service/DiscussionService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/DiscussionService.java
@@ -61,8 +61,8 @@ public class DiscussionService {
                 .description(request.getDescription())
                 .book(book)
                 .status(DiscussionStatus.ACTIVE)
-                //.endDate(LocalDateTime.now().plusWeeks(1))
-                .endDate(LocalDateTime.now().plusMinutes(1))
+                .endDate(LocalDateTime.now().plusWeeks(1))
+                //.endDate(LocalDateTime.now().plusMinutes(1))
                 .build();
 
         Discussion saved = discussionRepository.save(discussion);

--- a/src/main/java/com/fwaiya/princess_backend/service/DiscussionService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/DiscussionService.java
@@ -1,0 +1,17 @@
+package com.fwaiya.princess_backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiscussionService {
+
+    /** 토론방 전체 조회 **/
+
+    /** 토론방 개별 조회 **/
+
+    /** 토론방 등록 **/
+
+    /** 토론방 삭제 **/
+}

--- a/src/main/java/com/fwaiya/princess_backend/service/QuoteService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/QuoteService.java
@@ -1,0 +1,25 @@
+package com.fwaiya.princess_backend.service;
+
+import com.fwaiya.princess_backend.dto.response.QuoteResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class QuoteService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String URL = "https://korean-advice-open-api.vercel.app/api/advice";
+
+    public QuoteResponse getQuote(){
+        try {
+            ResponseEntity<QuoteResponse> response = restTemplate.getForEntity(URL, QuoteResponse.class);
+            return response.getBody();
+        } catch (Exception e) {
+            return new QuoteResponse("명언을 불러오지 못했습니다.", "시스템");
+        }
+    }
+
+}

--- a/src/main/java/com/fwaiya/princess_backend/service/UserService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/UserService.java
@@ -1,11 +1,16 @@
 package com.fwaiya.princess_backend.service;
 
 import com.fwaiya.princess_backend.domain.User;
-import com.fwaiya.princess_backend.global.api.ErrorCode;
-import com.fwaiya.princess_backend.global.exception.GeneralException;
+import com.fwaiya.princess_backend.domain.WantToRead;
+import com.fwaiya.princess_backend.dto.request.WantCreateRequest;
+import com.fwaiya.princess_backend.dto.response.UserInfoResponse;
+import com.fwaiya.princess_backend.global.constant.ProfileImageConstants;
 import com.fwaiya.princess_backend.repository.UserRepository;
+import com.fwaiya.princess_backend.repository.WantToReadRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
 
 
 /** *사용자 정보 관리하는 서비스 클래스 * 일단,, 사용자 닉네임 반환, 삭제 기능 제공**@author yaaan7 *@since 2025-06-29*/
@@ -13,18 +18,61 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final WantToReadRepository wantToReadRepository;
 
-    /** userId로 사용자 정보 조회 ** @param userId *@return nickname */
-    public String getNickname(String username) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
-        return user.getNickname();
+    // username 으로 사용자가 존재하는지 확인 -> controller에서 이용
+    @Transactional
+    public User findByUsername(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다: " + username));
     }
 
-    /** userId로 사용자 삭제 ** @param userId */
+    /** userId로 사용자 삭제  **/
+    @Transactional
     public void withdraw(String username) {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+        User user = findByUsername(username);
         userRepository.delete(user);
+    }
+
+    /** userId로 사용자 정보 조회 **/
+    @Transactional
+    public UserInfoResponse getUserInfo(String username) {
+        User user = findByUsername(username);
+        return UserInfoResponse.from(user);
+    }
+
+    /** 읽고 싶은 책 등록 **/
+    @Transactional
+    public void createWant(WantCreateRequest request, User user){
+
+        WantToRead wantToRead = new WantToRead();
+        wantToRead.setBookTitle(request.getBookTitle());
+        wantToRead.setAuthor(request.getAuthor());
+        wantToRead.setGenre(request.getGenre());
+        wantToRead.setMemo(request.getMemo());
+
+        user.addWantToRead(wantToRead);
+
+        userRepository.save(user); //wantToRead도 자동으로 저장
+    }
+
+    /** 읽고 싶은 책 삭제 **/
+    @Transactional
+    public void deleteWant(Long wantId, User user){
+        // 사용자 소유의 wantId가 맞는지 확인
+        WantToRead wantToRead = wantToReadRepository.findByIdAndUserId(wantId, user.getId())
+                .orElseThrow(() -> new IllegalArgumentException("삭제할 책이 존재하지 않거나 권한이 없습니다. ID:  " + wantId));
+
+        wantToReadRepository.delete(wantToRead);
+    }
+
+    /** 프로필 수정 기능**/
+    @Transactional
+    public void updateProfile(String imagePath, User user) {
+        // imagePath가 고정 이미지 리스트에 포함되는지 검증
+        if (!ProfileImageConstants.FIXED_IMAGES.contains(imagePath)) {
+            throw new IllegalArgumentException("허용되지 않은 프로필 이미지입니다.");
+        }
+        user.updateImagePath(imagePath);
     }
 }

--- a/src/main/java/com/fwaiya/princess_backend/service/UserService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/UserService.java
@@ -20,12 +20,18 @@ public class UserService {
     private final UserRepository userRepository;
     private final WantToReadRepository wantToReadRepository;
 
-    // username 으로 사용자가 존재하는지 확인 -> controller에서 이용
-    @Transactional
+    // username 으로 사용자가 존재하는지 확인
     public User findByUsername(String username) {
         return userRepository.findByUsername(username)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다: " + username));
     }
+
+    public void existByUsername(String username) {
+        if (!userRepository.existsByUsername(username)) {
+            throw new IllegalArgumentException("존재하지 않는 사용자입니다: " + username);
+        }
+    }
+
 
     /** userId로 사용자 삭제  **/
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 추가한 기능
### 토론방
* 토론방 등록 ( 관리자 권한 )
 -> ( username(id)가 1234@naver.com 일 경우 회원 가입 시에 관리자로 올라감)
 -> 책 이름(필수) 와 토론방 제목, 설명을 받아서 등록됨
 -> 책 이름으로 책을 조회해 진행되므로 테스트 시에 책 등록한 후 사용
* 토론방 전체 조회 ( 활성화 상태인 토론방 조회 )
* 토론방 개별 조회 ( 토론방 id를 받아 조회 )
* 토론방 자동 삭제 ( 기한 일주일 (테스트에서는 1분으로 테스트함!.) )
### 댓글
* 댓글 등록 ( 댓글 내용만 입력하여 등록 )
* 토론방별 댓글 목록 조회 ( 댓글 내용, 사용자 프로필 사진url, 닉네임, 리딩레벨 한국어를 목록으로 반환 )
### 명언 api
* 사용한 api 주소 : "https://korean-advice-open-api.vercel.app/api/advice"
* author, message 반환

모든 기능 스웨거에서 성공 테스트 완료 