### PR TITLE
refactor: 독서록 등록 시 bookId 제거, book 정보 포함 구조로 리팩토링

### DIFF
--- a/src/main/java/com/fwaiya/princess_backend/controller/AdminController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/AdminController.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/admin")
 @Tag(name = "07. 관리자 권한 기능 관리", description = " 관리자(1234@naver.com) 권한 기능을 사용할 수 있습니다. ")

--- a/src/main/java/com/fwaiya/princess_backend/controller/ReadingLogController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/ReadingLogController.java
@@ -29,8 +29,8 @@ public class ReadingLogController {
 
     /**
      * 독서록 등록
-     * - 로그인한 사용자가 새로운 독서록을 작성합니다.
-     * - 요청 본문으로 ReadingLogRequest를 받습니다.
+     * - 로그인한 사용자 -> 새로운 독서록 작성
+     * - 요청 본문: ReadingLogRequest
      */
     @PostMapping
     @Operation(summary = "독서록 등록", description = "로그인한 사용자가 독서록을 작성합니다.")
@@ -39,13 +39,12 @@ public class ReadingLogController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         readingLogService.createReadingLog(request, customUserDetails);
-        //return ResponseEntity.ok("독서록 등록을 완료하였습니다.");
         return ApiResponse.onSuccess(SuccessCode.READING_LOG_CREATE_SUCCESS, "True");
     }
 
     /**
      * 내 독서록 목록 조회
-     * - 로그인한 사용자가 작성한 모든 독서록을 조회합니다.
+     * - 로그인한 사용자가 작성한 모든 독서록 조회
      */
     @GetMapping("/my")
     @Operation(summary = "내 독서록 목록 조회", description = "로그인한 사용자의 독서록 목록을 조회합니다.")
@@ -53,14 +52,13 @@ public class ReadingLogController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         List<ReadingLogResponse> response = readingLogService.getMyReadingLogs(customUserDetails);
-        //return ResponseEntity.ok(response);
         return ApiResponse.onSuccess(SuccessCode.READING_LOG_LIST_GET_SUCCESS, response);
     }
 
     /**
      * 독서록 상세 조회
-     * - 로그인한 사용자가 작성한 단일 독서록을 조회합니다.
-     * - 다른 사용자의 독서록은 조회할 수 없습니다.
+     * - 로그인한 사용자가 작성한 단일 독서록 조회
+     * - 다른 사용자의 독서록은 조회 불가
      */
     @GetMapping("/{readingLogId}")
     @Operation(summary = "내 독서록 상세 조회", description = "내가 작성한 단일 독서록을 조회합니다.")
@@ -69,13 +67,11 @@ public class ReadingLogController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         ReadingLogResponse response = readingLogService.getReadingLogById(readingLogId, customUserDetails);
-        //return ResponseEntity.ok(response);
         return ApiResponse.onSuccess(SuccessCode.READING_LOG_DETAIL_GET_SUCCESS, response);
     }
 
     /**
      * 독서록 수정
-     * - 로그인한 사용자가 작성한 독서록을 수정합니다.
      */
     @PutMapping("/{readingLogId}")
     @Operation(summary = "독서록 수정", description = "로그인한 사용자가 작성한 독서록을 수정합니다.")
@@ -90,7 +86,7 @@ public class ReadingLogController {
 
     /**
      * 독서록 삭제
-     * - 로그인한 사용자가 작성한 독서록을 삭제합니다.
+     * - 로그인한 사용자가 작성한 독서록 삭제
      */
     @DeleteMapping("/{readingLogId}")
     @Operation(summary = "독서록 삭제", description = "로그인한 사용자가 작성한 독서록을 삭제합니다.")
@@ -99,7 +95,6 @@ public class ReadingLogController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         readingLogService.deleteReadingLog(readingLogId, customUserDetails);
-        //return ResponseEntity.ok("독서록 삭제를 완료하였습니다.");
         return ApiResponse.onSuccess(SuccessCode.READING_LOG_DELETE_SUCCESS, "True");
     }
 

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/BookRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/BookRequest.java
@@ -14,23 +14,24 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @NoArgsConstructor
+
 public class BookRequest {
 
     @NotBlank
-    @Schema(description = "책 제목", example = "나미야 잡화점의 기적")
+    @Schema(description = "책 제목", example = "넛지")
     private String title;
 
     @NotBlank
-    @Schema(description = "저자", example = "히가시노 게이고")
+    @Schema(description = "저자", example = "리처드 탈러, 캐스 선스타인")
     private String author;
 
     @NotNull
-    @Schema(description = "장르 (enum)", example = "fiction", implementation = Genre.class)
+    @Schema(description = "장르 (enum)", example = "humanities", implementation = Genre.class)
     private Genre genre;
 
-    @Schema(description = "책 표지 이미지 URL", example = "https://s3.bucket.com/image.jpg")
+    @Schema(description = "책 표지 이미지 URL", example = "https://s3.bucket.com/nudge.jpg")
     private String coverImageUrl;
 
-    @Schema(description = "해시태그", example = "#감동#힐링")
+    @Schema(description = "해시태그", example = "#행동경제학#넛지이론#선택설계#심리학")
     private String hashtags;
 }

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogRequest.java
@@ -1,5 +1,6 @@
 package com.fwaiya.princess_backend.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Lob;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -10,29 +11,45 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * ReadingLogRequest
- * 독서록 등록 및 수정 시 사용하는 요청 DTO 클래스입니다.
+ * [ReadingLogRequest]
+ * 사용자가 독서록을 작성하거나 수정할 때 요청 본문으로 전달하는 DTO 클래스
+ * 책 정보를 포함하여 한 번의 요청으로 독서록과 책을 동시에 등록
  */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "독서록 작성 요청 예시", example = """
+{
+  "book": {
+    "title": "이기적 유전자",
+    "author": "리처드 도킨스",
+    "genre": "science",
+    "coverImageUrl": "https://s3.bucket.com/selfish_gene.jpg",
+    "hashtags": "#진화#생물학#과학명저"
+  },
+  "oneLineReview": "진화론에 대한 시야가 넓어졌습니다.",
+  "content": "이 책은 생물학을 넘어서 인간 사회와 사고방식까지 통찰하게 해줍니다. 어렵지만 꼭 읽어야 할 과학 명저입니다.",
+  "rating": 5
+}
+""")
 public class ReadingLogRequest {
 
-    /** 책 ID */
-    @NotNull(message = "책 ID는 필수입니다.")
-    private Long bookId;
+    /**
+     * 독서록을 작성할 책의 정보
+     * - BookRequest 객체로 전달되며, 제목, 저자, 장르 등의 정보 포함
+     * - 해당 책이 DB에 없을 경우, 서버에서 자동으로 등록
+     */
+    @NotNull(message = "책 정보는 필수입니다.")
+    private BookRequest book;
 
-    /** 한 줄 평 */
-    @NotBlank(message = "한 줄 평 입력은 필수입니다.")
+    @NotBlank(message = "한 줄 평은 필수입니다.")
     private String oneLineReview;
 
-    /** 감상 내용 */
     @Lob
-    @NotBlank(message = "감상 내용 입력은 필수입니다.")
+    @NotBlank(message = "감상 내용은 필수입니다.")
     private String content;
 
-    /** 평점: 0~5 */
-    @NotNull(message = "평점 입력은 필수입니다.")
+    @NotNull(message = "평점은 필수입니다.")
     @Min(0)
     @Max(5)
     private Integer rating;

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/WantCreateRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/WantCreateRequest.java
@@ -2,6 +2,7 @@ package com.fwaiya.princess_backend.dto.request;
 
 import com.fwaiya.princess_backend.global.constant.Genre;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,6 +19,6 @@ public class WantCreateRequest {
     @NotBlank(message = "저자는 필수입니다.")
     private String author;
 
-    @NotBlank(message = "장르는 필수입니다.")
+    @NotNull(message = "장르는 필수입니다.")
     private Genre genre;
 }

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/ReadingLogResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/ReadingLogResponse.java
@@ -8,8 +8,9 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 /**
- * ReadingLogResponse
- * 독서록 조회 시 사용하는 응답 DTO 클래스입니다.
+ * [ReadingLogResponse]
+ * 독서록 단건 또는 목록 조회 시 클라이언트에게 전달되는 응답 DTO
+ * 독서록 자체 정보와 함께 연결된 책(Book)의 정보도 포함
  */
 @Getter
 @NoArgsConstructor
@@ -17,19 +18,28 @@ import java.time.LocalDateTime;
 public class ReadingLogResponse {
 
     private String oneLineReview;
+
     private String content;
+
     private Integer rating;
 
     private String bookTitle;
+
     private String bookAuthor;
+
+    // 연결된 책의 장르 (Enum → 문자열로 변환됨)
     private String bookGenre;
+
     private String bookHashtags;
+
+    // 책 표지 이미지 URL (S3 기반)
     private String bookCoverImageUrl;
 
     private LocalDateTime createdAt;
 
     /**
-     * ReadingLog 엔티티로부터 ReadingLogResponse 생성
+     * ReadingLog 엔티티로부터 응답 DTO 객체 생성
+     * - Book 엔티티 내부의 필드들을 함께 추출하여 응답에 포함시킴
      */
     public static ReadingLogResponse from(ReadingLog readingLog) {
         return new ReadingLogResponse(
@@ -38,7 +48,7 @@ public class ReadingLogResponse {
                 readingLog.getRating(),
                 readingLog.getBook().getTitle(),
                 readingLog.getBook().getAuthor(),
-                readingLog.getBook().getGenre().name(),
+                readingLog.getBook().getGenre().name(),  // Enum → String
                 readingLog.getBook().getHashtags(),
                 readingLog.getBook().getCoverImageUrl(),
                 readingLog.getCreatedAt()

--- a/src/main/java/com/fwaiya/princess_backend/global/SecurityConfig.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.fwaiya.princess_backend.global;
 
+import com.amazonaws.HttpMethod;
 import com.fwaiya.princess_backend.login.jwt.JWTFilter;
 import com.fwaiya.princess_backend.login.jwt.JWTUtil;
 import com.fwaiya.princess_backend.login.jwt.LoginFilter;

--- a/src/main/java/com/fwaiya/princess_backend/global/api/ErrorCode.java
+++ b/src/main/java/com/fwaiya/princess_backend/global/api/ErrorCode.java
@@ -41,6 +41,10 @@ public enum ErrorCode implements BaseCode { // 실패
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_4001", "해당 책 정보를 찾을 수 없습니다."),
     BOOK_TITLE_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_4002", "해당 제목의 책이 존재하지 않습니다."),
 
+    // ReadingLog
+    READING_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "READING_4002", "해당 독서록을 찾을 수 없습니다."),
+
+
     // Discussion
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "DISCUSSION_4001", "활성화된 토론방이 존재하지 않습니다."),
 

--- a/src/main/java/com/fwaiya/princess_backend/login/controller/JoinController.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/controller/JoinController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,7 +24,9 @@ public class JoinController {
 
     @Operation(summary = "회원가입", description = "사용자 정보를 받아 회원가입을 진행합니다.")
     @PostMapping("/join")
-    public ResponseEntity<String> joinProcess(JoinRequestDto joinRequestDto) {
+    public ResponseEntity<String> joinProcess(
+            @RequestBody JoinRequestDto joinRequestDto
+    ) {
         JoinResponseDto response = joinService.joinProcess(joinRequestDto);
         return ResponseEntity.ok("회원 가입을 성공하였습니다");
     }

--- a/src/main/java/com/fwaiya/princess_backend/login/jwt/LoginFilter.java
+++ b/src/main/java/com/fwaiya/princess_backend/login/jwt/LoginFilter.java
@@ -1,5 +1,7 @@
 package com.fwaiya.princess_backend.login.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fwaiya.princess_backend.login.dto.LoginRequestDto;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -22,14 +24,21 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     private final JWTUtil jwtUtil;
 
     @Override
-    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException{
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try{
+            ObjectMapper objectMapper = new ObjectMapper();
+            LoginRequestDto loginRequest = objectMapper.readValue(request.getInputStream(), LoginRequestDto.class);
 
-        String username = request.getParameter("userId");
-        String password = request.getParameter("password");
 
-        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password);
+            String username = loginRequest.getUserId();
+            String password = loginRequest.getPassword();
 
-        return authenticationManager.authenticate(authToken);
+            UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password);
+
+            return authenticationManager.authenticate(authToken);
+        } catch (IOException e) {
+            throw new RuntimeException("로그인 요청 파싱 실패", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/fwaiya/princess_backend/repository/BookRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/BookRepository.java
@@ -1,24 +1,23 @@
 package com.fwaiya.princess_backend.repository;
 
 import com.fwaiya.princess_backend.domain.Book;
-import com.fwaiya.princess_backend.domain.Discussion;
+import com.fwaiya.princess_backend.global.constant.Genre;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-// Book 엔티티에 대한 DB 접근을 담당하는 JPA Repository 인터페이스
-// JpaRepository<Book, Long>을 상속받아 기본 CRUD 기능을 자동으로 제공
+/**
+ * BookRepository
+ * Book 엔티티에 대한 JPA Repository
+ * 기본 CRUD + 사용자 정의 쿼리 메서드
+ */
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
+    // 제목으로 책 조회
     Optional<Book> findByTitle(String title);
 
-    // 기본적으로 다음과 같은 메서드를 자동으로 제공함:
-    // - findAll() : 전체 목록 조회
-    // - findById(Long id) : ID로 단건 조회
-    // - save(Book book) : 삽입 또는 수정
-    // - deleteById(Long id) : 삭제
-    // - existsById(Long id) : 존재 여부 확인
-
+    // 제목 + 저자 + 장르가 모두 일치하는 책 조회 (중복 방지용)
+    Optional<Book> findByTitleAndAuthorAndGenre(String title, String author, Genre genre);
 }

--- a/src/main/java/com/fwaiya/princess_backend/repository/ReadingLogRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/ReadingLogRepository.java
@@ -7,17 +7,16 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 /**
- * ReadingLogRepository
- * 독서록 데이터를 관리하는 JPA Repository 인터페이스
+ * [ReadingLogRepository]
+ * 독서록(ReadingLog) 엔티티에 대한 DB 접근을 담당하는 JPA Repository
+ * 기본 CRUD 외에도 사용자 정의 조회 메서드 추가
  */
 @Repository
 public interface ReadingLogRepository extends JpaRepository<ReadingLog, Long> {
 
     /**
-     * 특정 사용자 ID로 독서록 목록 조회
-     * @param userId 사용자 ID
-     * @return 독서록 리스트
+     * 특정 사용자 ID 기준으로 작성한 독서록 전체 목록 조회
+     * - 내 독서록 리스트 조회 용도
      */
     List<ReadingLog> findByUserId(Long userId);
-
 }

--- a/src/main/java/com/fwaiya/princess_backend/service/BookService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/BookService.java
@@ -15,7 +15,8 @@ import java.util.stream.Collectors;
 
 /**
  * BookService
- * 책 등록, 조회, 수정, 삭제와 같은 비즈니스 로직을 처리하는 서비스 클래스
+ * 책 등록, 조회,
+ * 수정, 삭제와 같은 비즈니스 로직을 처리하는 서비스 클래스
  */
 @Service
 @RequiredArgsConstructor
@@ -89,5 +90,29 @@ public class BookService {
             throw new GeneralException(ErrorCode.BOOK_NOT_FOUND);
         }
         bookRepository.deleteById(id);
+    }
+
+    /**
+     * [findOrCreateBook]
+     * title + author + genre 기준으로 책이 존재하면 반환,
+     * 존재하지 않으면 새로 등록한 뒤 반환
+     * → 독서록 작성 시 책 정보 기반으로 연결할 때 사용
+     */
+    @Transactional
+    public Book findOrCreateBook(BookRequest request) {
+        return bookRepository.findByTitleAndAuthorAndGenre(
+                request.getTitle(),
+                request.getAuthor(),
+                request.getGenre()
+        ).orElseGet(() -> {
+            Book newBook = Book.builder()
+                    .title(request.getTitle())
+                    .author(request.getAuthor())
+                    .genre(request.getGenre())
+                    .coverImageUrl(request.getCoverImageUrl())
+                    .hashtags(request.getHashtags())
+                    .build();
+            return bookRepository.save(newBook);
+        });
     }
 }

--- a/src/main/java/com/fwaiya/princess_backend/service/DiscussionService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/DiscussionService.java
@@ -72,12 +72,10 @@ public class DiscussionService {
     }
 
     /** 토론방 삭제 **/
-    @Scheduled(fixedRate = 60000)
+    @Scheduled(fixedRate = 3600000)
     @Transactional
     public void updateDiscussionStatus(){
 
-        // 활성화 되어 있고 일주일 전에 생성된 주문 찾기
-        // 정확히 일주일 전이 아닌 날짜만 보게끔 고쳐보자
         List<Discussion> expiredDiscussions = discussionRepository.findByStatusAndEndDateBefore(
                 DiscussionStatus.ACTIVE,
                 LocalDateTime.now()

--- a/src/main/java/com/fwaiya/princess_backend/service/ReadingLogService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/ReadingLogService.java
@@ -8,7 +8,6 @@ import com.fwaiya.princess_backend.dto.response.ReadingLogResponse;
 import com.fwaiya.princess_backend.global.api.ErrorCode;
 import com.fwaiya.princess_backend.global.exception.GeneralException;
 import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
-import com.fwaiya.princess_backend.repository.BookRepository;
 import com.fwaiya.princess_backend.repository.ReadingLogRepository;
 import com.fwaiya.princess_backend.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -18,23 +17,34 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * ReadingLogService
+ * 독서록의 등록, 조회, 수정, 삭제에 대한 비즈니스 로직 처리
+ */
 @Service
 @RequiredArgsConstructor
 public class ReadingLogService {
-    private final ReadingLogRepository readingLogRepository;
-    private final BookRepository bookRepository;
-    private final UserRepository userRepository;
 
-    /** 독서록 등록 기능 **/
+    private final ReadingLogRepository readingLogRepository;
+    private final UserRepository userRepository;
+    private final BookService bookService; // Book 등록 또는 재사용을 위임받음
+
+    /**
+     * 독서록 등록
+     * - 책 정보가 함께 전달됨
+     * - 책이 DB에 없으면 자동 등록
+     * - 책이 이미 있으면 해당 Book에 연결
+     */
     @Transactional
     public void createReadingLog(ReadingLogRequest request, CustomUserDetails customUserDetails) {
+        // 사용자 조회 (JWT 기반 인증 사용자)
         User user = userRepository.findByUsername(customUserDetails.getUsername())
-                //.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
-        Book book=bookRepository.findById(request.getBookId())
-                //.orElseThrow(() -> new IllegalArgumentException("책을 찾을 수 없습니다."));
-                .orElseThrow(() -> new GeneralException(ErrorCode.BOOK_NOT_FOUND));
 
+        // 책 중복 검사 후 없으면 새로 등록
+        Book book = bookService.findOrCreateBook(request.getBook());
+
+        // 독서록 생성 및 필드 설정
         ReadingLog readingLog = new ReadingLog();
         readingLog.setUser(user);
         readingLog.setBook(book);
@@ -42,69 +52,88 @@ public class ReadingLogService {
         readingLog.setContent(request.getContent());
         readingLog.setRating(request.getRating());
 
+        // 저장
         readingLogRepository.save(readingLog);
 
+        // 사용자의 읽은 책 수 및 레벨 갱신
         user.updateReadCountAndReadingLevel();
     }
 
-    /** 내 독서록 목록 조회 기능 **/
+    /**
+     * 내 독서록 전체 목록 조회
+     * - 현재 로그인한 사용자가 작성한 모든 독서록을 반환
+     */
     @Transactional
     public List<ReadingLogResponse> getMyReadingLogs(CustomUserDetails customUserDetails) {
         User user = userRepository.findByUsername(customUserDetails.getUsername())
-                //.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
         List<ReadingLog> logs = readingLogRepository.findByUserId(user.getId());
-        return logs.stream().map(ReadingLogResponse::from).collect(Collectors.toList());
+
+        // ReadingLog → ReadingLogResponse 변환
+        return logs.stream()
+                .map(ReadingLogResponse::from)
+                .collect(Collectors.toList());
     }
 
-    /** 내 독서록 단건 조회 기능 **/
+    /**
+     * 내 독서록 단건 조회
+     * - ID로 조회하되, 본인의 독서록만 접근 가능
+     */
     @Transactional
     public ReadingLogResponse getReadingLogById(Long readingLogId, CustomUserDetails customUserDetails) {
         User user = userRepository.findByUsername(customUserDetails.getUsername())
-                //.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
-        ReadingLog log = readingLogRepository.findById(readingLogId).orElseThrow();
+        ReadingLog log = readingLogRepository.findById(readingLogId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.READING_LOG_NOT_FOUND));
 
+        // 소유자 확인
         if (!log.getUser().getId().equals(user.getId())) {
-            //throw new SecurityException("본인의 독서록만 조회 가능합니다.");
             throw new GeneralException(ErrorCode.UNAUTHORIZED_READING_LOG_ACCESS);
         }
 
         return ReadingLogResponse.from(log);
     }
 
-    /** 독서록 수정 기능 **/
+    /**
+     * 독서록 수정
+     * - 한 줄 평, 감상 내용, 평점만 수정 가능
+     * - 책 정보는 수정하지 않음
+     */
     @Transactional
     public void updateReadingLog(Long readingLogId, ReadingLogRequest request, CustomUserDetails customUserDetails) {
         User user = userRepository.findByUsername(customUserDetails.getUsername())
-                //.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
-        ReadingLog log = readingLogRepository.findById(readingLogId).orElseThrow();
+        ReadingLog log = readingLogRepository.findById(readingLogId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.READING_LOG_NOT_FOUND));
 
+        // 소유자 확인
         if (!log.getUser().getId().equals(user.getId())) {
-           // throw new SecurityException("본인의 독서록만 수정 가능합니다.");
             throw new GeneralException(ErrorCode.UNAUTHORIZED_READING_LOG_UPDATE);
         }
 
+        // 필드 수정
         log.setOneLineReview(request.getOneLineReview());
         log.setContent(request.getContent());
         log.setRating(request.getRating());
     }
 
-    /** 독서록 삭제 기능 **/
+    /**
+     * 독서록 삭제
+     * - 본인만 삭제 가능
+     */
     @Transactional
     public void deleteReadingLog(Long readingLogId, CustomUserDetails customUserDetails) {
         User user = userRepository.findByUsername(customUserDetails.getUsername())
-                //.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
-        ReadingLog log = readingLogRepository.findById(readingLogId).orElseThrow();
+        ReadingLog log = readingLogRepository.findById(readingLogId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.READING_LOG_NOT_FOUND));
 
+        // 소유자 확인
         if (!log.getUser().getId().equals(user.getId())) {
-            //throw new SecurityException("본인의 독서록만 삭제 가능합니다.");
             throw new GeneralException(ErrorCode.UNAUTHORIZED_READING_LOG_DELETE);
         }
 


### PR DESCRIPTION
### 📌 주요 변경 사항
- ReadingLogRequest에서 bookId 필드 제거
- BookRequest를 포함하여 책 정보 전체를 JSON으로 전달받도록 변경
- BookService에 findOrCreateBook(BookRequest) 메서드 추가
  → 기존 책이 있으면 반환, 없으면 자동 등록
- ReadingLogService에서 BookRepository 직접 접근 제거, BookService 사용
- ErrorCode에 READING_LOG_NOT_FOUND 추가

### ✅ 테스트
- Swagger에서 책 정보 포함한 독서록 등록 성공 확인
- 기존 책과 동일한 title+author+genre 조합이면 중복 없이 연결됨

### 🔁 영향 받는 API
- POST /api/reading-logs (요청 구조 변경됨)

---

필요한 경우 코멘트 주세요 🙌
