### PR TITLE
refactor: 독서록 응답 필드 및 책 관계 구조 변경

### DIFF
--- a/src/main/java/com/fwaiya/princess_backend/domain/ReadingLog.java
+++ b/src/main/java/com/fwaiya/princess_backend/domain/ReadingLog.java
@@ -21,8 +21,8 @@ public class ReadingLog extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private String OneLineReview;
+    /*@Column(nullable = false)
+    private String OneLineReview;*/
 
     @Lob
     @Column(nullable = false)
@@ -33,8 +33,8 @@ public class ReadingLog extends BaseEntity {
     @Max(5)
     private int rating; // 별 0~5개
 
-    // 독서록과 책 연관관계 (1:1)
-    @OneToOne(fetch = FetchType.LAZY)
+    // 독서록과 책 연관관계 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")
     private Book book;
 

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/BookRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/BookRequest.java
@@ -29,7 +29,7 @@ public class BookRequest {
     @Schema(description = "장르 (enum)", example = "humanities", implementation = Genre.class)
     private Genre genre;
 
-    @Schema(description = "책 표지 이미지 URL", example = "https://s3.bucket.com/nudge.jpg")
+    @Schema(description = "책 표지 이미지 URL", example = "s3://princess-app-images/books/191b0b36-fbfa-49d5-b045-9eb181122f1e_IMG_3462.jpeg")
     private String coverImageUrl;
 
     @Schema(description = "해시태그", example = "#행동경제학#넛지이론#선택설계#심리학")

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogRequest.java
@@ -24,10 +24,9 @@ import lombok.NoArgsConstructor;
     "title": "이기적 유전자",
     "author": "리처드 도킨스",
     "genre": "science",
-    "coverImageUrl": "https://s3.bucket.com/selfish_gene.jpg",
+    "coverImageUrl": "s3://princess-app-images/books/191b0b36-fbfa-49d5-b045-9eb181122f1e_IMG_3462.jpeg",
     "hashtags": "#진화#생물학#과학명저"
   },
-  "oneLineReview": "진화론에 대한 시야가 넓어졌습니다.",
   "content": "이 책은 생물학을 넘어서 인간 사회와 사고방식까지 통찰하게 해줍니다. 어렵지만 꼭 읽어야 할 과학 명저입니다.",
   "rating": 5
 }
@@ -42,8 +41,8 @@ public class ReadingLogRequest {
     @NotNull(message = "책 정보는 필수입니다.")
     private BookRequest book;
 
-    @NotBlank(message = "한 줄 평은 필수입니다.")
-    private String oneLineReview;
+   /* @NotBlank(message = "한 줄 평은 필수입니다.")
+    private String oneLineReview;*/
 
     @Lob
     @NotBlank(message = "감상 내용은 필수입니다.")

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/ReadingLogResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/ReadingLogResponse.java
@@ -16,8 +16,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReadingLogResponse {
+    private Long readingLogId; // 추가된 필드
 
-    private String oneLineReview;
+    // private String oneLineReview;
 
     private String content;
 
@@ -43,7 +44,8 @@ public class ReadingLogResponse {
      */
     public static ReadingLogResponse from(ReadingLog readingLog) {
         return new ReadingLogResponse(
-                readingLog.getOneLineReview(),
+                readingLog.getId(),  // readingLogId 세팅
+                /*readingLog.getOneLineReview(),*/
                 readingLog.getContent(),
                 readingLog.getRating(),
                 readingLog.getBook().getTitle(),

--- a/src/main/java/com/fwaiya/princess_backend/service/ReadingLogService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/ReadingLogService.java
@@ -48,7 +48,7 @@ public class ReadingLogService {
         ReadingLog readingLog = new ReadingLog();
         readingLog.setUser(user);
         readingLog.setBook(book);
-        readingLog.setOneLineReview(request.getOneLineReview());
+        /*readingLog.setOneLineReview(request.getOneLineReview());*/
         readingLog.setContent(request.getContent());
         readingLog.setRating(request.getRating());
 
@@ -115,7 +115,7 @@ public class ReadingLogService {
         }
 
         // 필드 수정
-        log.setOneLineReview(request.getOneLineReview());
+        // log.setOneLineReview(request.getOneLineReview());
         log.setContent(request.getContent());
         log.setRating(request.getRating());
     }


### PR DESCRIPTION
## 📌 개요
독서록(ReadingLog) 관련 API의 응답 및 엔티티 구조를 개선합니다.  
- 클라이언트에서 독서록 식별이 용이하도록 `readingLogId`를 응답에 포함  
- 더 이상 사용하지 않는 `oneLineReview` 필드 제거  
- 독서록과 책 간의 관계를 `@ManyToOne`으로 명시하여 다대일 구조 확립

---

## ✨ 주요 변경 사항

- `ReadingLogResponse`
  - ✅ `readingLogId` 필드 추가
- `ReadingLogRequest`
  - 🗑️ `oneLineReview` 필드 제거
- `ReadingLog` Entity
  - 🛠️ `Book` 필드를 `@ManyToOne(fetch = FetchType.LAZY)`로 구조 변경
- `ReadingLogService`, `ReadingLogController`
  - 위 DTO/Entity 변경에 맞게 로직 수정

---

## 🧪 테스트

- Swagger에서 `독서록 등록 / 조회 / 수정 / 삭제` 정상 작동 확인
- Book 엔티티 연결 및 LAZY 로딩 문제 없음
- `readingLogId` 응답 필드 확인 완료

---

## 🔗 참고

- 관련 브랜치: 35-독서록-등록-리팩토링
