### PR TITLE
feat: 책 랭킹 조회 API 구현 + database 수정 -> 독서록 등록 확인

### DIFF
--- a/src/main/java/com/fwaiya/princess_backend/controller/BookController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/BookController.java
@@ -1,6 +1,7 @@
 package com.fwaiya.princess_backend.controller;
 
 import com.fwaiya.princess_backend.dto.request.BookRequest;
+import com.fwaiya.princess_backend.dto.response.BookRankingResponse;
 import com.fwaiya.princess_backend.dto.response.BookResponse;
 import com.fwaiya.princess_backend.global.api.ApiResponse;
 import com.fwaiya.princess_backend.global.api.SuccessCode;
@@ -28,7 +29,7 @@ public class BookController {
      * 책 등록
      */
     @PostMapping
-    @Operation(summary = "책 등록", description = "새로운 책 정보를 등록합니다.")
+    @Operation(summary = "Swagger 전용 책 등록", description = "새로운 책 정보를 등록합니다.")
     public ApiResponse<String> createBook(@RequestBody BookRequest request) {
         bookService.saveBook(request);
         return ApiResponse.onSuccess(SuccessCode.BOOK_CREATE_SUCCESS, "True");
@@ -38,7 +39,7 @@ public class BookController {
      * 전체 책 목록 조회
      */
     @GetMapping
-    @Operation(summary = "전체 책 목록 조회", description = "등록된 모든 책 정보를 조회합니다.")
+    @Operation(summary = "Swagger 전용 전체 책 목록 조회", description = "등록된 모든 책 정보를 조회합니다.")
     public ApiResponse<List<BookResponse>> getAllBooks() {
         List<BookResponse> books = bookService.getAllBooks();
         return ApiResponse.onSuccess(SuccessCode.BOOK_LIST_GET_SUCCESS, books);
@@ -48,7 +49,7 @@ public class BookController {
      * 특정 책 상세 조회
      */
     @GetMapping("/{bookId}")
-    @Operation(summary = "책 상세 조회", description = "책 ID를 통해 특정 책 정보를 조회합니다.")
+    @Operation(summary = "Swagger 전용 책 상세 조회", description = "책 ID를 통해 특정 책 정보를 조회합니다.")
     public ApiResponse<BookResponse> getBookById(@PathVariable Long bookId) {
         BookResponse book = bookService.getBook(bookId);
         return ApiResponse.onSuccess(SuccessCode.BOOK_DETAIL_GET_SUCCESS, book);
@@ -58,7 +59,7 @@ public class BookController {
      * 책 정보 수정
      */
     @PutMapping("/{bookId}")
-    @Operation(summary = "책 정보 수정", description = "책 ID를 기준으로 책 정보를 수정합니다.")
+    @Operation(summary = "Swagger 전용 책 정보 수정", description = "책 ID를 기준으로 책 정보를 수정합니다.")
     public ApiResponse<String> updateBook(@PathVariable Long bookId, @RequestBody BookRequest request) {
         bookService.updateBook(bookId, request);
         return ApiResponse.onSuccess(SuccessCode.BOOK_UPDATE_SUCCESS, "True");
@@ -68,9 +69,22 @@ public class BookController {
      * 책 삭제
      */
     @DeleteMapping("/{bookId}")
-    @Operation(summary = "책 삭제", description = "책 ID를 기준으로 해당 책을 삭제합니다.")
+    @Operation(summary = "Swagger 전용 책 삭제", description = "책 ID를 기준으로 해당 책을 삭제합니다.")
     public ApiResponse<String> deleteBook(@PathVariable Long bookId) {
         bookService.deleteBook(bookId);
         return ApiResponse.onSuccess(SuccessCode.BOOK_DELETE_SUCCESS, "True");
     }
+
+    /**
+     * 독서록 수 기준 책 랭킹 조회 API
+     * - GET /api/books/ranking
+     * - 홈 화면 상단에 노출할 인기 책 리스트
+     */
+    @GetMapping("/ranking")
+    @Operation(summary = "책 랭킹 조회", description = "독서록이 가장 많이 작성된 책을 인기 순으로 최대 8개까지 반환합니다.")
+    public ApiResponse<List<BookRankingResponse>> getBookRanking() {
+        List<BookRankingResponse> rankings = bookService.getBookRanking();
+        return ApiResponse.onSuccess(SuccessCode.BOOK_LIST_GET_SUCCESS, rankings);  // 리스트 형태로 응답
+    }
+
 }

--- a/src/main/java/com/fwaiya/princess_backend/dto/response/BookRankingResponse.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/response/BookRankingResponse.java
@@ -1,0 +1,21 @@
+package com.fwaiya.princess_backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 독서록 수 기준 책 랭킹 응답 DTO
+ * - 홈 화면에서 랭킹 리스트를 표시할 때 사용
+ */
+@Getter
+@AllArgsConstructor
+public class BookRankingResponse {
+
+    private Long id;                 // 책 ID
+    private String title;            // 책 제목
+    private String author;           // 저자
+    private String hashtags;         // 책 해시태그
+    private String coverImageUrl;    // 표지 이미지 URL
+    private long readingLogCount;    // 해당 책의 독서록 작성 수
+}
+

--- a/src/main/java/com/fwaiya/princess_backend/repository/BookRepository.java
+++ b/src/main/java/com/fwaiya/princess_backend/repository/BookRepository.java
@@ -1,10 +1,15 @@
 package com.fwaiya.princess_backend.repository;
 
 import com.fwaiya.princess_backend.domain.Book;
+import com.fwaiya.princess_backend.dto.response.BookRankingResponse;
 import com.fwaiya.princess_backend.global.constant.Genre;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+
+import org.springframework.data.domain.Pageable;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -20,4 +25,27 @@ public interface BookRepository extends JpaRepository<Book, Long> {
 
     // 제목 + 저자 + 장르가 모두 일치하는 책 조회 (중복 방지용)
     Optional<Book> findByTitleAndAuthorAndGenre(String title, String author, Genre genre);
+
+    /**
+     * 독서록이 가장 많이 작성된 책 상위 8개 조회
+     * - ReadingLog를 기준으로 book_id 별 COUNT
+     * - 개수가 8개 미만이면 있는 만큼만 반환
+     */
+    @Query("""
+    SELECT new com.fwaiya.princess_backend.dto.response.BookRankingResponse(
+        b.id,
+        b.title,
+        b.author,
+        b.hashtags,
+        b.coverImageUrl,
+        COUNT(rl.id)
+    )
+    FROM ReadingLog rl
+    JOIN rl.book b
+    GROUP BY b.id
+    ORDER BY COUNT(rl.id) DESC
+""")
+    List<BookRankingResponse> findTop8BooksByReadingLogCount(Pageable pageable);
+
+
 }

--- a/src/main/java/com/fwaiya/princess_backend/service/BookService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/BookService.java
@@ -2,12 +2,15 @@ package com.fwaiya.princess_backend.service;
 
 import com.fwaiya.princess_backend.domain.Book;
 import com.fwaiya.princess_backend.dto.request.BookRequest;
+import com.fwaiya.princess_backend.dto.response.BookRankingResponse;
 import com.fwaiya.princess_backend.dto.response.BookResponse;
 import com.fwaiya.princess_backend.global.api.ErrorCode;
 import com.fwaiya.princess_backend.global.exception.GeneralException;
 import com.fwaiya.princess_backend.repository.BookRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest; // ✅ 올바른 import
+import org.springframework.data.domain.Pageable;   // ✅ 올바른 import
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -115,4 +118,16 @@ public class BookService {
             return bookRepository.save(newBook);
         });
     }
+
+    /**
+     * 독서록이 가장 많이 작성된 책 TOP 8을 조회
+     * - PageRequest.of(0, 8)로 최대 8개 제한
+     */
+
+    @Transactional
+    public List<BookRankingResponse> getBookRanking() {
+        Pageable pageable = PageRequest.of(0, 8); // 최대 8개
+        return bookRepository.findTop8BooksByReadingLogCount(pageable);
+    }
+
 }


### PR DESCRIPTION
## 🔍 PR 개요
- 책 랭킹 조회 API (독서록 수 기준 Top.8) 구현
- database column 수정하여 독서록 정상 등록 확인
- database unique 속성 수정하여 같은 책 1권에 대해 여러 독서록 생성 가능하도록 설계

## ✨ 주요 변경 사항
- `BookService` : `getBookRanking()` 메서드 추가
- `BookRepository` : 독서록 수 기준 정렬 쿼리 추가
- `BookController` : `/api/books/ranking` 엔드포인트 추가
- `BookRankingResponse` : 랭킹 응답용 DTO 생성

## 📌 API 설명
- **GET /api/books/ranking**
- 독서록 수 기준 상위 8권의 책을 조회합니다.
- 최대 8개, 부족하면 존재하는 개수만 반환합니다.

## 🔍 API 명세

| 메서드 | 경로                  | 설명                          |
|--------|-----------------------|-------------------------------|
| GET    | `/api/books/ranking` | 독서록 수 기준 랭킹 상위 8권 조회 |

### 📘 응답 예시
```json
[
  {
    "id": 1,
    "title": "이기적 유전자",
    "author": "리처드 도킨스",
    "hashtags": "#생물학#진화론",
    "coverImageUrl": "https://...",
    "readingLogCount": 12
  }
]
