### PR TITLE
✨ feat: 독서록 등록 멀티파트 업로드 기능 추가

### DIFF
--- a/src/main/java/com/fwaiya/princess_backend/controller/ReadingLogController.java
+++ b/src/main/java/com/fwaiya/princess_backend/controller/ReadingLogController.java
@@ -1,5 +1,8 @@
 package com.fwaiya.princess_backend.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fwaiya.princess_backend.dto.request.ReadingLogMultipartDoc;
 import com.fwaiya.princess_backend.dto.request.ReadingLogRequest;
 import com.fwaiya.princess_backend.dto.response.ReadingLogResponse;
 import com.fwaiya.princess_backend.global.api.ApiResponse;
@@ -7,10 +10,14 @@ import com.fwaiya.princess_backend.global.api.SuccessCode;
 import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
 import com.fwaiya.princess_backend.service.ReadingLogService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -27,20 +34,41 @@ public class ReadingLogController {
 
     private final ReadingLogService readingLogService;
 
+    // 스프링이 자동 주입해주는 ObjectMapper
+    private final ObjectMapper objectMapper;
+
     /**
      * 독서록 등록
      * - 로그인한 사용자 -> 새로운 독서록 작성
      * - 요청 본문: ReadingLogRequest
      */
-    @PostMapping
-    @Operation(summary = "독서록 등록", description = "로그인한 사용자가 독서록을 작성합니다.")
+    @PostMapping(
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @Operation(
+            summary = "독서록 등록(파일 업로드)",
+            description = "multipart/form-data로 readingLog(JSON) + coverImage(파일, 선택) 전송",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(implementation = ReadingLogMultipartDoc.class) // 문서 전용 래퍼 DTO(읽기용)
+                    )
+            )
+    )
     public ApiResponse<String> createReadingLog(
-            @RequestBody ReadingLogRequest request,
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
-    ) {
-        readingLogService.createReadingLog(request, customUserDetails);
+            @RequestPart("readingLog") String readingLogJson,                  // ← 문자열로 받기
+            @RequestPart(value = "coverImage", required = false) MultipartFile coverImage,
+            @AuthenticationPrincipal CustomUserDetails customUser
+    ) throws JsonProcessingException {
+        ReadingLogRequest readingLog = objectMapper.readValue(readingLogJson, ReadingLogRequest.class);
+        readingLogService.createWithBookUpsert(
+                readingLog.getBook(), coverImage, readingLog.getContent(), readingLog.getRating(), customUser
+        );
         return ApiResponse.onSuccess(SuccessCode.READING_LOG_CREATE_SUCCESS, "True");
     }
+
 
     /**
      * 내 독서록 목록 조회

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/BookRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/BookRequest.java
@@ -29,7 +29,17 @@ public class BookRequest {
     @Schema(description = "장르 (enum)", example = "humanities", implementation = Genre.class)
     private Genre genre;
 
-    @Schema(description = "책 표지 이미지 URL", example = "s3://princess-app-images/books/191b0b36-fbfa-49d5-b045-9eb181122f1e_IMG_3462.jpeg")
+    /**
+     * @deprecated 파일 업로드 방식으로 대체됨.
+     * 독서록 작성(multipart/form-data) 경로에서는 파일이 있을 경우 이 값은 무시
+     * (기존 JSON 호출 연착륙용으로 한시 유지)
+     */
+    @Deprecated
+    @Schema(
+            description = "책 표지 이미지 URL (Deprecated: 파일 업로드 방식으로 대체됨. 멀티파트 경로에서는 무시됨)",
+            example = "https://.../books/uuid_IMG_3462.jpeg",
+            deprecated = true
+    )
     private String coverImageUrl;
 
     @Schema(description = "해시태그", example = "#행동경제학#넛지이론#선택설계#심리학")

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogMultipartDoc.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogMultipartDoc.java
@@ -1,0 +1,20 @@
+package com.fwaiya.princess_backend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter @Setter
+@Schema(name = "ReadingLogMultipartDoc", description = "multipart/form-data RequestBody (문서 전용)")
+public class ReadingLogMultipartDoc {
+
+    @Schema(
+            description = "독서록 JSON 바디",
+            implementation = ReadingLogRequest.class // ← ReadingLogRequest 구조를 Swagger에 그대로 노출
+    )
+    private ReadingLogRequest readingLog;
+
+    @Schema(description = "표지 이미지 파일(선택)", type = "string", format = "binary")
+    private MultipartFile coverImage;
+}

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogRequest.java
@@ -10,46 +10,57 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 /**
  * [ReadingLogRequest]
- * 사용자가 독서록을 작성하거나 수정할 때 요청 본문으로 전달하는 DTO 클래스
- * 책 정보를 포함하여 한 번의 요청으로 독서록과 책을 동시에 등록
+ * 독서록 작성/수정 요청 DTO
+ * - multipart/form-data 전송 시: @RequestPart("readingLog") 로 이 객체를 JSON으로
+ * - 표지 이미지는 별도 파트 coverImage(파일)로 전송.
  */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "독서록 작성 요청 예시", example = """
+@Schema(
+        name = "ReadingLogRequest",
+        description = "독서록 작성 요청 바디(JSON). 파일은 별도 파트 coverImage로 전송",
+        example = """
 {
   "book": {
     "title": "이기적 유전자",
     "author": "리처드 도킨스",
     "genre": "science",
-    "coverImageUrl": "s3://princess-app-images/books/191b0b36-fbfa-49d5-b045-9eb181122f1e_IMG_3462.jpeg",
+    "coverImageUrl": "https://... (파일이 있으면 서버에서 이 값은 무시)",
     "hashtags": "#진화#생물학#과학명저"
   },
-  "content": "이 책은 생물학을 넘어서 인간 사회와 사고방식까지 통찰하게 해줍니다. 어렵지만 꼭 읽어야 할 과학 명저입니다.",
+  "content": "이 책은 생물학을 넘어서 인간 사회와 사고방식까지 통찰하게 해줍니다.",
   "rating": 5
 }
-""")
+"""
+)
 public class ReadingLogRequest {
 
-    /**
-     * 독서록을 작성할 책의 정보
-     * - BookRequest 객체로 전달되며, 제목, 저자, 장르 등의 정보 포함
-     * - 해당 책이 DB에 없을 경우, 서버에서 자동으로 등록
-     */
     @NotNull(message = "책 정보는 필수입니다.")
+    @Schema(
+            description = "책 정보(JSON). 파일 업로드가 있을 경우 book.coverImageUrl은 무시됨",
+            implementation = BookRequest.class
+    )
     private BookRequest book;
 
-   /* @NotBlank(message = "한 줄 평은 필수입니다.")
-    private String oneLineReview;*/
 
     @Lob
     @NotBlank(message = "감상 내용은 필수입니다.")
+    @Schema(
+            description = "독서록 본문",
+            example = "이 책은 생물학을 넘어서 인간 사회와 사고방식까지 통찰하게 해줍니다."
+    )
     private String content;
 
     @NotNull(message = "평점은 필수입니다.")
-    @Min(0)
-    @Max(5)
+    @Min(0) @Max(5)
+    @Schema(
+            description = "평점(0~5)",
+            minimum = "0", maximum = "5",
+            example = "5"
+    )
     private Integer rating;
 }

--- a/src/main/java/com/fwaiya/princess_backend/service/ReadingLogService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/ReadingLogService.java
@@ -3,16 +3,19 @@ package com.fwaiya.princess_backend.service;
 import com.fwaiya.princess_backend.domain.Book;
 import com.fwaiya.princess_backend.domain.ReadingLog;
 import com.fwaiya.princess_backend.domain.User;
+import com.fwaiya.princess_backend.dto.request.BookRequest;
 import com.fwaiya.princess_backend.dto.request.ReadingLogRequest;
 import com.fwaiya.princess_backend.dto.response.ReadingLogResponse;
 import com.fwaiya.princess_backend.global.api.ErrorCode;
 import com.fwaiya.princess_backend.global.exception.GeneralException;
 import com.fwaiya.princess_backend.login.jwt.CustomUserDetails;
+import com.fwaiya.princess_backend.repository.BookRepository;
 import com.fwaiya.princess_backend.repository.ReadingLogRepository;
 import com.fwaiya.princess_backend.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,6 +31,7 @@ public class ReadingLogService {
     private final ReadingLogRepository readingLogRepository;
     private final UserRepository userRepository;
     private final BookService bookService; // Book 등록 또는 재사용을 위임받음
+    private final S3Service s3Service;
 
     /**
      * 독서록 등록
@@ -35,29 +39,75 @@ public class ReadingLogService {
      * - 책이 DB에 없으면 자동 등록
      * - 책이 이미 있으면 해당 Book에 연결
      */
+
     @Transactional
-    public void createReadingLog(ReadingLogRequest request, CustomUserDetails customUserDetails) {
-        // 사용자 조회 (JWT 기반 인증 사용자)
-        User user = userRepository.findByUsername(customUserDetails.getUsername())
+    public void createWithBookUpsert(
+            BookRequest bookReq,
+            MultipartFile coverImage,
+            String content,
+            Integer rating,
+            CustomUserDetails cu
+    ) {
+        // 1) 사용자
+        User user = userRepository.findByUsername(cu.getUsername())
                 .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
 
-        // 책 중복 검사 후 없으면 새로 등록
-        Book book = bookService.findOrCreateBook(request.getBook());
+        // 2) 책 업서트 (createReadingLog와 동일한 정책으로 통일)
+        //    - title + author + genre 기준으로 조회, 없으면 생성
+        Book book = bookService.findOrCreateBook(bookReq);
 
-        // 독서록 생성 및 필드 설정
-        ReadingLog readingLog = new ReadingLog();
-        readingLog.setUser(user);
-        readingLog.setBook(book);
-        /*readingLog.setOneLineReview(request.getOneLineReview());*/
-        readingLog.setContent(request.getContent());
-        readingLog.setRating(request.getRating());
+        // 해시태그가 비어 있거나 기존 책에 없으면 최신 값으로 보정
+        if ((book.getHashtags() == null || book.getHashtags().isBlank())
+                && bookReq.getHashtags() != null) {
+            book.setHashtags(bookReq.getHashtags());
+        }
 
-        // 저장
-        readingLogRepository.save(readingLog);
+        // 3) 커버 파일이 있으면 S3 업로드 후 URL 교체 (파일 우선)
+        if (coverImage != null && !coverImage.isEmpty()) {
+            String url = s3Service.uploadBookCoverImage(coverImage);
+            book.setCoverImageUrl(url);
+            // JPA 변경감지로 커버 URL이 갱신됨
+        } else if (book.getCoverImageUrl() == null && bookReq.getCoverImageUrl() != null) {
+            // (연착륙) 파일이 없고 DB에도 없을 때만, 요청의 URL을 한시 허용
+            book.setCoverImageUrl(bookReq.getCoverImageUrl());
+        }
 
-        // 사용자의 읽은 책 수 및 레벨 갱신
+        // 4) 독서록 생성
+        ReadingLog log = new ReadingLog();
+        log.setUser(user);
+        log.setBook(book);
+        log.setContent(content);
+        log.setRating(rating);
+        readingLogRepository.save(log);
+
+        // 5) 부가 처리
         user.updateReadCountAndReadingLevel();
     }
+
+
+//    @Transactional
+//    public void createReadingLog(ReadingLogRequest request, CustomUserDetails customUserDetails) {
+//        // 사용자 조회 (JWT 기반 인증 사용자)
+//        User user = userRepository.findByUsername(customUserDetails.getUsername())
+//                .orElseThrow(() -> new GeneralException(ErrorCode.USER_NOT_FOUND));
+//
+//        // 책 중복 검사 후 없으면 새로 등록
+//        Book book = bookService.findOrCreateBook(request.getBook());
+//
+//        // 독서록 생성 및 필드 설정
+//        ReadingLog readingLog = new ReadingLog();
+//        readingLog.setUser(user);
+//        readingLog.setBook(book);
+//        /*readingLog.setOneLineReview(request.getOneLineReview());*/
+//        readingLog.setContent(request.getContent());
+//        readingLog.setRating(request.getRating());
+//
+//        // 저장
+//        readingLogRepository.save(readingLog);
+//
+//        // 사용자의 읽은 책 수 및 레벨 갱신
+//        user.updateReadCountAndReadingLevel();
+//    }
 
     /**
      * 내 독서록 전체 목록 조회


### PR DESCRIPTION
## 📌 개요
- 독서록 등록 시 book, content, rating JSON과 coverImage 파일을 multipart/form-data로 업로드 가능하도록 구현

## 🔄 주요 변경 사항
- ReadingLogRequest: Swagger 예시(JSON) 추가
- ReadingLogController: @RequestPart 기반 멀티파트 처리 로직 추가
- Service 계층에서 book upsert + 파일 업로드 기능 호출

## 🧪 테스트 방법
1. Swagger UI 실행
2. POST /api/reading-logs 호출
3. book(JSON), content, rating 입력 후 coverImage 파일 업로드
4. 정상적으로 DB 반영 및 S3 업로드 여부 확인

## ⚠ 참고 사항
- 기존 단일 JSON 요청 방식은 유지되지 않음
- coverImage는 선택값이며, 미업로드 시 기본 URL 적용
