### PR TITLE
✨ refactor: 독서록 등록/수정 시 coverImage 파일 업로드 방식으로 통일

### DIFF
--- a/src/main/java/com/fwaiya/princess_backend/dto/request/BookRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/BookRequest.java
@@ -29,18 +29,6 @@ public class BookRequest {
     @Schema(description = "장르 (enum)", example = "humanities", implementation = Genre.class)
     private Genre genre;
 
-    /**
-     * @deprecated 파일 업로드 방식으로 대체됨.
-     * 독서록 작성(multipart/form-data) 경로에서는 파일이 있을 경우 이 값은 무시
-     * (기존 JSON 호출 연착륙용으로 한시 유지)
-     */
-    @Deprecated
-    @Schema(
-            description = "책 표지 이미지 URL (Deprecated: 파일 업로드 방식으로 대체됨. 멀티파트 경로에서는 무시됨)",
-            example = "https://.../books/uuid_IMG_3462.jpeg",
-            deprecated = true
-    )
-    private String coverImageUrl;
 
     @Schema(description = "해시태그", example = "#행동경제학#넛지이론#선택설계#심리학")
     private String hashtags;

--- a/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogRequest.java
+++ b/src/main/java/com/fwaiya/princess_backend/dto/request/ReadingLogRequest.java
@@ -29,7 +29,6 @@ import lombok.NoArgsConstructor;
     "title": "이기적 유전자",
     "author": "리처드 도킨스",
     "genre": "science",
-    "coverImageUrl": "https://... (파일이 있으면 서버에서 이 값은 무시)",
     "hashtags": "#진화#생물학#과학명저"
   },
   "content": "이 책은 생물학을 넘어서 인간 사회와 사고방식까지 통찰하게 해줍니다.",
@@ -41,7 +40,7 @@ public class ReadingLogRequest {
 
     @NotNull(message = "책 정보는 필수입니다.")
     @Schema(
-            description = "책 정보(JSON). 파일 업로드가 있을 경우 book.coverImageUrl은 무시됨",
+            description = "책 정보(JSON).",
             implementation = BookRequest.class
     )
     private BookRequest book;

--- a/src/main/java/com/fwaiya/princess_backend/service/BookService.java
+++ b/src/main/java/com/fwaiya/princess_backend/service/BookService.java
@@ -28,7 +28,7 @@ public class BookService {
     private final BookRepository bookRepository;
 
     /**
-     * 책 등록
+     * 책 등록  (이 엔드포인트는 이제 표지 이미지를 다루지 않음)
      */
     @Transactional
     public void saveBook(BookRequest request) {
@@ -36,7 +36,6 @@ public class BookService {
                 .title(request.getTitle())
                 .author(request.getAuthor())
                 .genre(request.getGenre())
-                .coverImageUrl(request.getCoverImageUrl())
                 .hashtags(request.getHashtags())
                 .build();
 
@@ -65,7 +64,7 @@ public class BookService {
     }
 
     /**
-     * 책 정보 수정
+     * 책 정보 수정 (표지 URL은 건드리지 않고 유지)
      */
     @Transactional
     public void updateBook(Long id, BookRequest request) {
@@ -77,7 +76,7 @@ public class BookService {
                 .title(request.getTitle())
                 .author(request.getAuthor())
                 .genre(request.getGenre())
-                .coverImageUrl(request.getCoverImageUrl())
+                .coverImageUrl(original.getCoverImageUrl())
                 .hashtags(request.getHashtags())
                 .build();
 
@@ -100,6 +99,7 @@ public class BookService {
      * title + author + genre 기준으로 책이 존재하면 반환,
      * 존재하지 않으면 새로 등록한 뒤 반환
      * → 독서록 작성 시 책 정보 기반으로 연결할 때 사용
+     * 표지 URL은 여기서 세팅하지 않음 (파일 업로드 경로에서만 반영)
      */
     @Transactional
     public Book findOrCreateBook(BookRequest request) {
@@ -112,7 +112,6 @@ public class BookService {
                     .title(request.getTitle())
                     .author(request.getAuthor())
                     .genre(request.getGenre())
-                    .coverImageUrl(request.getCoverImageUrl())
                     .hashtags(request.getHashtags())
                     .build();
             return bookRepository.save(newBook);


### PR DESCRIPTION
## 📌 주요 변경 사항
- BookRequest DTO에서 coverImageUrl 필드 제거 (파일 업로드 방식으로만 처리)
- ReadingLogController 수정
  - 등록(create) 시 coverImage를 반드시 파일 업로드하도록 변경
  - 수정(update) 시도 coverImage 파일 업로드 방식으로 통일
- ReadingLogService 수정
  - S3Service를 통해 coverImage 파일 업로드
  - URL 입력 방식 완전히 제거
- BookService는 findOrCreateBook 시 coverImageUrl을 더 이상 사용하지 않음

## ✅ 테스트
- Swagger에서 독서록 등록 시 파일 업로드 정상 동작 확인
- 독서록 수정 시 파일 업로드 정상 반영 확인